### PR TITLE
Disabled Regional module

### DIFF
--- a/EMF/decisions/emf_maintenance_decisions.txt
+++ b/EMF/decisions/emf_maintenance_decisions.txt
@@ -4,6 +4,7 @@ decisions = {
 		is_high_prio = yes
 		
 		potential = {
+			always = no
 			# TO-TRY: Would the special trigger 'isis = { character = ROOT }' be more
 			# efficient generally for narrowing the engine down to Isis?  Would it work
 			# (cached+unique traits have special syntax for this purpose which I've seen


### PR DESCRIPTION
Until alternate approach can be worked out, Regional modules crashes
when used in conjunction with SWMH. To quote Lemongrab: UNACCEPTABLE!!!!!
