### PR TITLE
Added event not being triggered

### DIFF
--- a/EMF+VEvents/common/on_actions/00_on_actions.txt
+++ b/EMF+VEvents/common/on_actions/00_on_actions.txt
@@ -1176,6 +1176,7 @@ on_five_year_pulse = {
 		2 = VIETmisc.5043 #Alfred the Great
 		2 = VIETmisc.5054 #Succubus
 		2 = VIETmisc.5060 #TOOTHBRUSHING IMOUTO non-incest
+		2 = VIETmisc.5061 #Fast Love/Kogarashi Sentiment
 		
 		80 = 0
 	}


### PR DESCRIPTION
Only affected EMF version of VIET Events, btw, seems like I remembered to put this in for the non-EMF versions.
