### PR TITLE
Find Hobby blocked for WoL users

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -1,4 +1,5 @@
 EMF 3.03 [BETA]
+	[Ambitions] Blocked the Find Hobby ambition if using Way of Life DLC, as it isn't compatible with the Way of Life method for assigning lifestyle traits
 	Vassal AIs must be king-tier or higher to fabricate claims outside their realm; however, vassal duke AIs may do so as well if the target realm's top liege is a player
 	AI rulers won't use de jure county claims, de jure duchy claims, or third-party de jure county claims to conquer AI merchant republics' capitals unless they are themselves another merchant republic and not part of the same greater realm
 	Distribute Recently Acquired Titles:

--- a/EMF/common/objectives/emf_obj_find_hobby.txt
+++ b/EMF/common/objectives/emf_obj_find_hobby.txt
@@ -3,6 +3,7 @@ obj_find_hobby = {
 	type = character
 	
 	allow = {
+		not = { has_dlc = "Way of Life" } # This ambition doesn't currently do anything when WoL is activated
 		age = 20
 		NOT = { lifestyle_traits = 1 }
 	}


### PR DESCRIPTION
It doesn't currently do anything if you have Way of Life, so there's no reason for it to be showing up