### PR TITLE
Adjusted Jewish councilor generation events

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -1,4 +1,5 @@
 EMF 3.04 [BETA]
+	Jewish councilor events now include an option to refuse and if accepted give appropriate sympathy traits and opinion modifiers so the generated councilors are more useful
 	Great Goddess Isis no longer picks WoL focuses-- it can be lonely being Mother of the Universe, but it's part of the job.
 
 

--- a/EMF/events/emf_vanilla.txt
+++ b/EMF/events/emf_vanilla.txt
@@ -969,3 +969,51 @@ character_event = {
 	
 	option = { name = EXCELLENT }
 }
+
+## Jewish Councilor Related
+## 40-44 reserved
+# Hands out appropriate sympathy trait
+character_event = {
+	id = emf_vanilla.40
+	hide_window = yes
+	is_triggered_only = yes
+	
+	option = {
+		name = OK
+		if = {
+			limit = {
+				liege = { religion_group = christian }
+			}
+			add_trait = sympathy_christendom
+			break = yes
+		}
+		if = {
+			limit = {
+				liege = { religion_group = muslim }
+			}
+			add_trait = sympathy_islam
+			break = yes
+		}
+		if = {
+			limit = {
+				liege = { religion_group = zoroastrian_group }
+			}
+			add_trait = sympathy_zoroastrianism
+			break = yes
+		}
+		if = {
+			limit = {
+				liege = { religion_group = pagan_group }
+			}
+			add_trait = sympathy_pagans
+			break = yes
+		}
+		if = {
+			limit = {
+				liege = { religion_group = indian_group }
+			}
+			add_trait = sympathy_indian
+			break = yes
+		}
+	}
+}

--- a/EMF/events/soa_jewish_events.txt
+++ b/EMF/events/soa_jewish_events.txt
@@ -237,6 +237,16 @@ character_event = {
 		}
 		hidden_tooltip = { # EMF: Get Sympathy for liege
 			new_character = {
+				opinion = {
+					modifier = opinion_respects_liege
+					who = ROOT
+					years = 30
+				}
+				reverse_opinion = {
+					modifier = opinion_gained_respect
+					who = ROOT
+					years = 30
+				}
 				character_event = { id = emf_vanilla.40 }
 			}
 		}
@@ -326,6 +336,16 @@ character_event = {
 		}
 		hidden_tooltip = { # EMF: Get Sympathy for liege
 			new_character = {
+				opinion = {
+					modifier = opinion_respects_liege
+					who = ROOT
+					years = 30
+				}
+				reverse_opinion = {
+					modifier = opinion_gained_respect
+					who = ROOT
+					years = 30
+				}
 				character_event = { id = emf_vanilla.40 }
 			}
 		}
@@ -415,6 +435,16 @@ character_event = {
 		}
 		hidden_tooltip = { # EMF: Get Sympathy for liege
 			new_character = {
+				opinion = {
+					modifier = opinion_respects_liege
+					who = ROOT
+					years = 30
+				}
+				reverse_opinion = {
+					modifier = opinion_gained_respect
+					who = ROOT
+					years = 30
+				}
 				character_event = { id = emf_vanilla.40 }
 			}
 		}
@@ -503,6 +533,16 @@ character_event = {
 		}
 		hidden_tooltip = { # EMF: Get Sympathy for liege
 			new_character = {
+				opinion = {
+					modifier = opinion_respects_liege
+					who = ROOT
+					years = 30
+				}
+				reverse_opinion = {
+					modifier = opinion_gained_respect
+					who = ROOT
+					years = 30
+				}
 				character_event = { id = emf_vanilla.40 }
 			}
 		}
@@ -591,6 +631,16 @@ character_event = {
 		}
 		hidden_tooltip = { # EMF: Get Sympathy for liege
 			new_character = {
+				opinion = {
+					modifier = opinion_respects_liege
+					who = ROOT
+					years = 30
+				}
+				reverse_opinion = {
+					modifier = opinion_gained_respect
+					who = ROOT
+					years = 30
+				}
 				character_event = { id = emf_vanilla.40 }
 			}
 		}
@@ -679,6 +729,16 @@ character_event = {
 		}
 		hidden_tooltip = { # EMF: Get Sympathy for liege
 			new_character = {
+				opinion = {
+					modifier = opinion_respects_liege
+					who = ROOT
+					years = 30
+				}
+				reverse_opinion = {
+					modifier = opinion_gained_respect
+					who = ROOT
+					years = 30
+				}
 				character_event = { id = emf_vanilla.40 }
 			}
 		}

--- a/EMF/events/soa_jewish_events.txt
+++ b/EMF/events/soa_jewish_events.txt
@@ -1,0 +1,1165 @@
+###################################
+#
+# THE SONS OF ABRAHAM 
+# - Jewish Events
+#
+###################################
+
+namespace = SoA
+
+# Third Temple Construction Begun
+character_event = {
+	id = SoA.100
+	desc = EVTDESC_SoA_100
+	picture = GFX_evt_castle_construction
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	hide_from = yes
+	
+	option = {
+		name = EVTOPTA_SoA_100
+		set_global_flag = building_third_temple
+		custom_tooltip = { text = third_temple_construction }
+	}
+}
+
+# Third Temple Built
+province_event = {
+	id = SoA.10199
+	
+	hide_window = yes
+	
+	is_triggered_only = yes
+	
+	immediate = {
+		owner = { narrative_event = { id = SoA.101 } }
+	}
+}
+
+narrative_event = {
+	id = SoA.101
+	title = EVTNAME_SoA_101
+	desc = EVTDESC_SoA_101
+	picture = GFX_evt_jerusalem_captured_jews
+	border = GFX_event_narrative_frame_religion
+	major = yes
+	
+	is_triggered_only = yes
+	
+	hide_from = yes
+	
+	major_trigger = {
+		ai = no
+		religion = jewish
+	}
+	
+	immediate = {
+		set_global_flag = third_temple_built
+		clr_global_flag = building_third_temple
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_101
+	}
+}
+
+# Creation of Israel
+narrative_event = {
+	id = SoA.102
+	title = EVTNAME_SoA_102
+	desc = EVTDESC_SoA_102
+	picture = GFX_evt_jerusalem_captured_jews
+	border = GFX_event_narrative_frame_religion
+	
+	is_triggered_only = yes
+	
+	hide_from = yes
+	
+	immediate = {
+		set_character_flag = achievement_kingdom_of_david
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_102
+		primary_title = {
+			k_israel = {
+				grant_title = ROOT
+				copy_title_laws = PREV
+			}
+		}
+	}
+}
+
+# Jews Expelled
+character_event = {
+	id = SoA.105
+	desc = EVTDESC_SoA_105
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	hide_from = yes
+	
+	option = {
+		name = EVTOPTA_SoA_105
+		wealth = 200
+		prestige = -100
+		banish_religion = jewish
+		hidden_tooltip = {
+			any_realm_lord = {
+				limit = { 
+					OR = {
+						ai = no
+						has_character_modifier = borrowed_from_jews
+					}
+				}
+				character_event = { id = SoA.107 }
+			}
+		}
+	}
+}
+
+# Jews Welcomed Back
+character_event = {
+	id = SoA.106
+	desc = EVTDESC_SoA_106
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	hide_from = yes
+	
+	option = {
+		name = EVTOPTA_SoA_106
+		prestige = 50
+		hidden_tooltip = {
+			any_realm_lord = {
+				limit = { ai = no }
+				character_event = { id = SoA.108 }
+			}
+		}
+	}
+}
+
+# Jews Expelled (Notifier for Vassals)
+character_event = {
+	id = SoA.107
+	desc = EVTDESC_SoA_107
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_107
+		trigger = {
+			NOT = { has_character_modifier = borrowed_from_jews }
+		}
+	}
+	option = {
+		name = EVTOPTB_SoA_107
+		trigger = {
+			has_character_modifier = borrowed_from_jews
+		}
+		remove_character_modifier = borrowed_from_jews
+	}
+}
+
+# Jews Welcomed Back (Notifier for Vassals)
+character_event = {
+	id = SoA.108
+	desc = EVTDESC_SoA_108
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_107
+	}
+}
+
+### Jewish Court Events
+
+# Jewish Diplomat Appears at Court (Ashkenazi)
+character_event = {
+	id = SoA.200
+	desc = EVTDESC_SoA_200
+	picture = GFX_evt_emissary
+	border = GFX_event_normal_frame_religion
+	
+	min_age = 16
+	prisoner = no
+	only_playable = yes
+	capable_only = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		independent = yes
+		OR = {
+			religion_group = christian
+			religion_group = muslim
+			religion_group = zoroastrian_group
+			religion_group = jewish_group
+			culture = khazar
+		}
+		NOT = { 
+			capital_scope = {
+				empire = { title = e_spain }
+			}
+			has_character_modifier = expelled_jewish
+			trait = incapable
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 1100
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_200
+		create_character = {
+			random_traits = yes
+			culture = ashkenazi
+			dynasty = culture
+			religion = jewish
+			female = no
+			age = 30
+			trait = charismatic_negotiator
+			attributes = {
+				diplomacy = 10
+			}
+			flag = ai_flag_refuse_conversion
+		}
+		hidden_tooltip = { # EMF: Get Sympathy for liege
+			new_character = {
+				character_event = { id = emf_vanilla.40 }
+			}
+		}
+		if = { # EMF: Remove Zealous, add Sympathy
+			limit = {
+				not = { religion_group = jewish_group }
+			}
+			if = {
+				limit = { trait = zealous }
+				remove_trait = zealous
+			}
+			add_trait = sympathy_judaism
+		}
+		ai_chance = { # EMF: Zealous non-Jewish AI will never accept
+			factor = 100
+			modifier = {
+				factor = 0
+				trait = zealous
+				not = { religion_group = jewish_group }
+			}
+		}
+	}
+	option = { # EMF: Refuse
+		ai_chance = { # EMF: Not-Zealous or Jewish AI will never refuse
+			factor = 100
+			modifier = {
+				factor = 0
+				or = {
+					not = { trait = zealous }
+					religion_group = jewish_group
+				}
+			}
+		}
+		name = emf_vanilla_soa_200
+	}
+}
+
+# Jewish Administrator Appears at Court (Ashkenazi)
+character_event = {
+	id = SoA.201
+	desc = EVTDESC_SoA_201
+	picture = GFX_evt_emissary
+	border = GFX_event_normal_frame_religion
+	
+	min_age = 16
+	prisoner = no
+	only_playable = yes
+	capable_only = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		independent = yes
+		OR = {
+			religion_group = christian
+			religion_group = muslim
+			religion_group = zoroastrian_group
+			religion_group = jewish_group
+			culture = khazar
+		}	
+		NOT = { 
+			capital_scope = {
+				empire = { title = e_spain }
+			}
+			has_character_modifier = expelled_jewish
+			trait = incapable
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 1100
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_200
+		create_character = {
+			random_traits = yes
+			culture = ashkenazi
+			dynasty = culture
+			religion = jewish
+			female = no
+			age = 30
+			trait = fortune_builder
+			attributes = {
+				stewardship = 10
+			}
+			flag = ai_flag_refuse_conversion
+		}
+		hidden_tooltip = { # EMF: Get Sympathy for liege
+			new_character = {
+				character_event = { id = emf_vanilla.40 }
+			}
+		}
+		if = { # EMF: Remove Zealous, add Sympathy
+			limit = {
+				not = { religion_group = jewish_group }
+			}
+			if = {
+				limit = { trait = zealous }
+				remove_trait = zealous
+			}
+			add_trait = sympathy_judaism
+		}
+		ai_chance = { # EMF: Zealous non-Jewish AI will never accept
+			factor = 100
+			modifier = {
+				factor = 0
+				trait = zealous
+				not = { religion_group = jewish_group }
+			}
+		}
+	}
+	option = { # EMF: Refuse
+		ai_chance = { # EMF: Not-Zealous or Jewish AI will never refuse
+			factor = 100
+			modifier = {
+				factor = 0
+				or = {
+					not = { trait = zealous }
+					religion_group = jewish_group
+				}
+			}
+		}
+		name = emf_vanilla_soa_200
+	}
+}
+
+# Jewish Spy Appears at Court (Ashkenazi)
+character_event = {
+	id = SoA.202
+	desc = EVTDESC_SoA_202
+	picture = GFX_evt_emissary
+	border = GFX_event_normal_frame_religion
+	
+	min_age = 16
+	prisoner = no
+	only_playable = yes
+	capable_only = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		independent = yes
+		OR = {
+			religion_group = christian
+			religion_group = muslim
+			religion_group = zoroastrian_group
+			religion_group = jewish_group
+			culture = khazar
+		}
+		NOT = { 
+			capital_scope = {
+				empire = { title = e_spain }
+			}
+			has_character_modifier = expelled_jewish
+			trait = incapable
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 1100
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_200
+		create_character = {
+			random_traits = yes
+			culture = ashkenazi
+			dynasty = culture
+			religion = jewish
+			female = no
+			age = 30
+			trait = intricate_webweaver
+			attributes = {
+				intrigue = 10
+			}
+			flag = ai_flag_refuse_conversion
+		}
+		hidden_tooltip = { # EMF: Get Sympathy for liege
+			new_character = {
+				character_event = { id = emf_vanilla.40 }
+			}
+		}
+		if = { # EMF: Remove Zealous, add Sympathy
+			limit = {
+				not = { religion_group = jewish_group }
+			}
+			if = {
+				limit = { trait = zealous }
+				remove_trait = zealous
+			}
+			add_trait = sympathy_judaism
+		}
+		ai_chance = { # EMF: Zealous non-Jewish AI will never accept
+			factor = 100
+			modifier = {
+				factor = 0
+				trait = zealous
+				not = { religion_group = jewish_group }
+			}
+		}
+	}
+	option = { # EMF: Refuse
+		ai_chance = { # EMF: Not-Zealous or Jewish AI will never refuse
+			factor = 100
+			modifier = {
+				factor = 0
+				or = {
+					not = { trait = zealous }
+					religion_group = jewish_group
+				}
+			}
+		}
+		name = emf_vanilla_soa_200
+	}
+}
+
+# Jewish Diplomat Appears at Court (Sephardi)
+character_event = {
+	id = SoA.203
+	desc = EVTDESC_SoA_200
+	picture = GFX_evt_emissary
+	border = GFX_event_normal_frame_religion
+	
+	min_age = 16
+	prisoner = no
+	only_playable = yes
+	capable_only = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		independent = yes
+		capital_scope = {
+			empire = { title = e_spain }
+		}
+		OR = {
+			religion_group = christian
+			religion_group = muslim
+			religion_group = zoroastrian_group
+			religion_group = jewish_group
+		}	
+		NOT = { 
+			has_character_modifier = expelled_jewish
+			trait = incapable
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 750
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_200
+		create_character = {
+			random_traits = yes
+			culture = sephardi
+			dynasty = culture
+			religion = jewish
+			female = no
+			age = 30
+			trait = charismatic_negotiator
+			attributes = {
+				diplomacy = 10
+			}
+			flag = ai_flag_refuse_conversion
+		}
+		hidden_tooltip = { # EMF: Get Sympathy for liege
+			new_character = {
+				character_event = { id = emf_vanilla.40 }
+			}
+		}
+		if = { # EMF: Remove Zealous, add Sympathy
+			limit = {
+				not = { religion_group = jewish_group }
+			}
+			if = {
+				limit = { trait = zealous }
+				remove_trait = zealous
+			}
+			add_trait = sympathy_judaism
+		}
+		ai_chance = { # EMF: Zealous non-Jewish AI will never accept
+			factor = 100
+			modifier = {
+				factor = 0
+				trait = zealous
+				not = { religion_group = jewish_group }
+			}
+		}
+	}
+	option = { # EMF: Refuse
+		ai_chance = { # EMF: Not-Zealous or Jewish AI will never refuse
+			factor = 100
+			modifier = {
+				factor = 0
+				or = {
+					not = { trait = zealous }
+					religion_group = jewish_group
+				}
+			}
+		}
+		name = emf_vanilla_soa_200
+	}
+}
+
+# Jewish Administrator Appears at Court (Sephardi)
+character_event = {
+	id = SoA.204
+	desc = EVTDESC_SoA_201
+	picture = GFX_evt_emissary
+	border = GFX_event_normal_frame_religion
+	
+	min_age = 16
+	prisoner = no
+	only_playable = yes
+	capable_only = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		independent = yes
+		capital_scope = {
+			empire = { title = e_spain }
+		}
+		OR = {
+			religion_group = christian
+			religion_group = muslim
+			religion_group = zoroastrian_group
+			religion_group = jewish_group
+		}	
+		NOT = { 
+			has_character_modifier = expelled_jewish
+			trait = incapable
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 750
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_200
+		create_character = {
+			random_traits = yes
+			culture = sephardi
+			dynasty = culture
+			religion = jewish
+			female = no
+			age = 30
+			trait = fortune_builder
+			attributes = {
+				stewardship = 10
+			}
+			flag = ai_flag_refuse_conversion
+		}
+		hidden_tooltip = { # EMF: Get Sympathy for liege
+			new_character = {
+				character_event = { id = emf_vanilla.40 }
+			}
+		}
+		if = { # EMF: Remove Zealous, add Sympathy
+			limit = {
+				not = { religion_group = jewish_group }
+			}
+			if = {
+				limit = { trait = zealous }
+				remove_trait = zealous
+			}
+			add_trait = sympathy_judaism
+		}
+		ai_chance = { # EMF: Zealous non-Jewish AI will never accept
+			factor = 100
+			modifier = {
+				factor = 0
+				trait = zealous
+				not = { religion_group = jewish_group }
+			}
+		}
+	}
+	option = { # EMF: Refuse
+		ai_chance = { # EMF: Not-Zealous or Jewish AI will never refuse
+			factor = 100
+			modifier = {
+				factor = 0
+				or = {
+					not = { trait = zealous }
+					religion_group = jewish_group
+				}
+			}
+		}
+		name = emf_vanilla_soa_200
+	}
+}
+
+# Jewish Spy Appears at Court (Sephardi)
+character_event = {
+	id = SoA.205
+	desc = EVTDESC_SoA_202
+	picture = GFX_evt_emissary
+	border = GFX_event_normal_frame_religion
+	
+	min_age = 16
+	prisoner = no
+	only_playable = yes
+	capable_only = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		independent = yes
+		capital_scope = {
+			empire = { title = e_spain }
+		}
+		OR = {
+			religion_group = christian
+			religion_group = muslim
+			religion_group = zoroastrian_group
+			religion_group = jewish_group
+		}	
+		NOT = { 
+			has_character_modifier = expelled_jewish
+			trait = incapable
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 750
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_200
+		create_character = {
+			random_traits = yes
+			culture = sephardi
+			dynasty = culture
+			religion = jewish
+			female = no
+			age = 30
+			trait = intricate_webweaver
+			attributes = {
+				intrigue = 10
+			}
+			flag = ai_flag_refuse_conversion
+		}
+		hidden_tooltip = { # EMF: Get Sympathy for liege
+			new_character = {
+				character_event = { id = emf_vanilla.40 }
+			}
+		}
+		if = { # EMF: Remove Zealous, add Sympathy
+			limit = {
+				not = { religion_group = jewish_group }
+			}
+			if = {
+				limit = { trait = zealous }
+				remove_trait = zealous
+			}
+			add_trait = sympathy_judaism
+		}
+		ai_chance = { # EMF: Zealous non-Jewish AI will never accept
+			factor = 100
+			modifier = {
+				factor = 0
+				trait = zealous
+				not = { religion_group = jewish_group }
+			}
+		}
+	}
+	option = { # EMF: Refuse
+		ai_chance = { # EMF: Not-Zealous or Jewish AI will never refuse
+			factor = 100
+			modifier = {
+				factor = 0
+				or = {
+					not = { trait = zealous }
+					religion_group = jewish_group
+				}
+			}
+		}
+		name = emf_vanilla_soa_200
+	}
+}
+
+### Jewish Expulsion Events
+
+# Loss of economic tech
+character_event = {
+	id = SoA.300
+	desc = EVTDESC_SoA_300
+	picture = GFX_evt_bad_news
+	border = GFX_event_normal_frame_religion
+	
+	trigger = {
+		has_character_modifier = expelled_jewish
+	}
+	
+	mean_time_to_happen = {
+		months = 680
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_300
+		economy_techpoints = -50
+	}
+}
+
+# Loss of cultural tech
+character_event = {
+	id = SoA.301
+	desc = EVTDESC_SoA_301
+	picture = GFX_evt_bad_news
+	border = GFX_event_normal_frame_religion
+	
+	trigger = {
+		has_character_modifier = expelled_jewish
+	}
+	
+	mean_time_to_happen = {
+		months = 680
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_301
+		culture_techpoints = -50
+	}
+}
+
+# Loss of military tech
+character_event = {
+	id = SoA.302
+	desc = EVTDESC_SoA_302
+	picture = GFX_evt_bad_news
+	border = GFX_event_normal_frame_religion
+	
+	trigger = {
+		has_character_modifier = expelled_jewish
+	}
+	
+	mean_time_to_happen = {
+		months = 680
+	}
+	
+	option = {
+		name = EVTOPTA_SoA_302
+		military_techpoints = -50
+	}
+}
+
+### Jewish Passover
+
+# Invitation Sent
+character_event = {
+	id = SoA.500
+	desc = EVTDESC_SoA_500
+	picture = GFX_evt_synagogue
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	hide_from = yes
+	
+	option = {
+		name = EVTOPTA_SoA_500
+		any_vassal = {
+			limit = {
+				religion = jewish
+				age = 16
+				prisoner = no
+				war = no
+				NOT = { trait = incapable }
+			}
+			character_event = { id = SoA.501 days = 2 tooltip = EVTTOOLTIP_SoA_501 }
+		}
+		custom_tooltip = { text = passover_invitations_sent }
+		hidden_tooltip = { character_event = { id = SoA.503 days = 10 } }
+		hidden_tooltip = { character_event = { id = SoA.504 days = 12 } }
+	}
+}
+
+# Invitation Received
+character_event = {
+	id = SoA.501
+	desc = EVTDESC_SoA_501
+	picture = GFX_evt_synagogue
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_501
+		ai_chance = {
+			factor = 80
+			modifier  = {
+				factor = 0.1
+				ai = yes
+				trait = in_hiding
+			}
+			modifier = {
+				factor = 0
+				NOT = {	opinion = { who = ROOT value = -20 } }
+			}
+		}
+		custom_tooltip = { text = passover_accepted }
+		set_character_flag = attending_passover
+		set_character_flag = do_not_disturb
+		hidden_tooltip = { character_event = { id = SoA.503 days = 8 } }
+		hidden_tooltip = { character_event = { id = SoA.599 days = 20 } } # Safety catch flag clearing
+		if = {
+			limit = { trait = in_hiding	}
+			remove_trait = in_hiding
+			add_character_modifier = {
+				name = went_out_of_hiding_timer
+				duration = 180
+				hidden = yes
+			}
+			hidden_tooltip = { character_event = { id = CM.6400 } } # Notify plotters and family
+		}
+	}
+	option = {
+		name = EVTOPTB_SoA_501
+		ai_chance = {
+			factor = 20
+		}
+		FROM = {
+			opinion = {
+				modifier = opinion_refused_passover
+				who = ROOT
+			}
+		}
+		custom_tooltip = { text = passover_declined }
+		hidden_tooltip = {
+			FROM = { character_event = { id = SoA.502 } }
+		}
+	}
+}
+
+# Invitation Refused
+character_event = {
+	id = SoA.502
+	desc = EVTDESC_SoA_502
+	picture = GFX_evt_synagogue
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_502
+		opinion = {
+			modifier = opinion_refused_passover
+			who = FROM
+		}
+	}
+}
+
+# Passover Sedar Begins
+character_event = {
+	id = SoA.503
+	desc = EVTDESC_SoA_503
+	picture = GFX_evt_synagogue
+	border = GFX_event_normal_frame_religion
+	
+	hide_from = yes
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_503
+	}
+}
+
+# Passover Sedar Ends (Host)
+character_event = {
+	id = SoA.504
+	desc = EVTDESC_SoA_504
+	picture = GFX_evt_synagogue
+	border = GFX_event_normal_frame_religion
+	
+	hide_from = yes
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_504
+		any_vassal = {
+			limit = { has_character_flag = attending_passover }
+			opinion = {
+				modifier = opinion_passover
+				who = ROOT
+			}
+		}
+		hidden_tooltip = {
+			any_vassal = {
+				limit = { has_character_flag = attending_passover }
+				character_event = { id = SoA.505 }
+			}
+		}
+		add_character_modifier = {
+			name = held_passover_timer
+			duration = 1825
+			hidden = yes
+		}
+		prestige = 100
+		piety = 100
+		clr_character_flag = holding_passover
+		clr_character_flag = do_not_disturb
+	}
+}
+
+# Passover Sedar Ends (Guest)
+character_event = {
+	id = SoA.505
+	desc = EVTDESC_SoA_505
+	picture = GFX_evt_synagogue
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_504
+		clr_character_flag = attending_passover
+		clr_character_flag = do_not_disturb
+	}
+}
+
+# The Priesthood Restored
+narrative_event = {
+	id = SoA.550
+	title = EVTNAME_SoA_550
+	desc = EVTDESC_SoA_550
+	picture = GFX_evt_synagogue
+	border = GFX_event_narrative_frame_religion
+	
+	major = yes
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_550
+		trigger = {
+			religion_group = jewish_group
+		}
+	}
+	option = {
+		name = EVTOPTB_TOG_6004
+		trigger = {
+			NOT = {
+				religion_group = jewish_group
+				religion_group = muslim
+			}
+		}
+	}
+	option = {
+		name = EVTOPTC_TOG_6004
+		trigger = {
+			religion_group = muslim
+		}
+	}
+}
+
+### Jewish Councillor Events
+
+# Chancellor (Hidden)
+character_event = {
+	id = SoA.560
+	hide_window = yes
+	
+	trigger = {
+		religion_group = jewish_group
+		has_job_title = job_chancellor
+		employer = {
+			NOT = { religion_group = jewish_group }
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 280
+		modifier = {
+			factor = 0.5
+			OR = {
+				has_focus = focus_scholarship
+				liege = { has_focus = focus_scholarship }
+			}
+		}
+	}
+	
+	immediate = {
+		employer = {
+			character_event = { id = SoA.561 }
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Chancellor
+character_event = {
+	id = SoA.561
+	desc = EVTDESC_SoA_561
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_561
+		culture_techpoints = 50
+	}
+}
+
+# Steward (Hidden)
+character_event = {
+	id = SoA.562
+	hide_window = yes
+	
+	trigger = {
+		religion_group = jewish_group
+		has_job_title = job_treasurer
+		employer = {
+			NOT = { religion_group = jewish_group }
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 280
+		modifier = {
+			factor = 0.5
+			OR = {
+				has_focus = focus_scholarship
+				liege = { has_focus = focus_scholarship }
+			}
+		}
+	}
+	
+	immediate = {
+		employer = {
+			character_event = { id = SoA.563 }
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Steward
+character_event = {
+	id = SoA.563
+	desc = EVTDESC_SoA_563
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_561
+		economy_techpoints = 50
+	}
+}
+
+# Spymaster (Hidden)
+character_event = {
+	id = SoA.564
+	hide_window = yes
+	
+	trigger = {
+		religion_group = jewish_group
+		has_job_title = job_spymaster
+		employer = {
+			NOT = { religion_group = jewish_group }
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 280
+		modifier = {
+			factor = 0.5
+			OR = {
+				has_focus = focus_scholarship
+				liege = { has_focus = focus_scholarship }
+			}
+		}
+	}
+	
+	immediate = {
+		employer = {
+			character_event = { id = SoA.565 }
+		}
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Spymaster
+character_event = {
+	id = SoA.565
+	desc = EVTDESC_SoA_565
+	picture = GFX_evt_jewish_market
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA_SoA_561
+		military_techpoints = 50
+	}
+}
+
+###########################################
+# Flag management                         #
+###########################################
+
+# Safety catch - clears character flags and modifiers
+character_event = {
+	id = SoA.599
+
+	hide_window = yes
+	
+	is_triggered_only = yes
+	
+	immediate = {
+		clr_character_flag = do_not_disturb
+		clr_character_flag = holding_passover
+		clr_character_flag = attending_passover
+	}
+}
+

--- a/EMF/localisation/emf_vanilla.csv
+++ b/EMF/localisation/emf_vanilla.csv
@@ -1,3 +1,4 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
 emf_vanilla.20.desc;§Y[From.Location.GetName]§! was converted to the §Y[From.Religion.GetName]§! faith!;;;;;;;;;;;;;x
 emf_vanilla.21.desc;Under the guidance of your [Root.GetMarshalName], §Y[From.Location.GetName]§! will enjoy ample levy reinforcements for the next two years.;;;;;;;;;;;;;x
+emf_vanilla_soa_200;No thanks.;;;;;;;;;;;;;x


### PR DESCRIPTION
Jewish councilor events now include an option to refuse, and if accepted they give appropriate sympathy traits and opinion modifiers so the prospective councilors are more useful