### PR TITLE
Adjust AI weights for murder event

### DIFF
--- a/EMF+VEvents/common/on_actions/00_on_actions.txt
+++ b/EMF+VEvents/common/on_actions/00_on_actions.txt
@@ -270,6 +270,25 @@ on_yearly_pulse = {
 		# Other Charlemagne/Carloman
 		100 = CM.1130
 
+		# Way of Life Theology focus
+		1000 = WoL.7000
+		1000 = WoL.7010
+		1000 = WoL.7020
+		1000 = WoL.7030
+		1000 = WoL.7040
+		1000 = WoL.7050
+		1000 = WoL.7060
+		1000 = WoL.7070
+
+		# Way of Life Hunting focus
+		2000 = WoL.5000 # Epic Hunt chain start
+		2000 = WoL.5200 # Receive hunting dog
+		1000 = WoL.5210 # Dog makes you happy
+		1000 = WoL.5211 # Dog makes you popular
+		1000 = WoL.5220 # Train your dog?
+		1000 = WoL.5230 # Bad dog kills other dog
+		1000 = WoL.5231 # Bad dog kills or wounds courtier
+		
 		#VIET EVENTS
 		#Generic Set 1
 		100 = VIETnam.71
@@ -541,15 +560,10 @@ on_yearly_pulse = {
 		100 = VIETmisc.2047
 		100 = VIETmisc.2048
 		100 = VIETmisc.2049
-		100 = VIETmisc.2050
 		100 = VIETmisc.2051
-		100 = VIETmisc.2052
-		100 = VIETmisc.2053
 		100 = VIETmisc.2054
 		100 = VIETmisc.2055
 		100 = VIETmisc.2056
-		100 = VIETmisc.2010
-		100 = VIETmisc.2012
 		#War
 		100 = VIETmisc.2255
 		100 = VIETmisc.2256
@@ -576,6 +590,15 @@ on_yearly_pulse = {
 		100 = VIETmisc.2280
 		100 = VIETmisc.2281
 		100 = VIETmisc.2284
+		#Moss
+		100 = VIETmisc.2290
+		100 = VIETmisc.2291
+		100 = VIETmisc.2292
+		#Animals
+		100 = VIETmisc.2293
+		100 = VIETmisc.2296
+		100 = VIETmisc.2306
+
 		
 		#VIET CULTURE SPECIFIC EVENTS
 		#African
@@ -637,7 +660,7 @@ on_yearly_pulse = {
 		100 = VIETmisc.2043
 		
 		#VIET IMMERSION STUFF
-		#Vegetarian flavor - removed
+		#Vegetarian flavor removed
 
 		#VIET Marriage Stuff
 		100 = ordepmarriage.1000
@@ -651,25 +674,6 @@ on_yearly_pulse = {
 		#VIET MISC STUFF
 		100 = VIETmisc.2519
 		100 = VIETmisc.2520
-		
-		# Way of Life Theology focus
-		1000 = WoL.7000
-		1000 = WoL.7010
-		1000 = WoL.7020
-		1000 = WoL.7030
-		1000 = WoL.7040
-		1000 = WoL.7050
-		1000 = WoL.7060
-		1000 = WoL.7070
-
-		# Way of Life Hunting focus
-		2000 = WoL.5000 # Epic Hunt chain start
-		2000 = WoL.5200 # Receive hunting dog
-		1000 = WoL.5210 # Dog makes you happy
-		1000 = WoL.5211 # Dog makes you popular
-		1000 = WoL.5220 # Train your dog?
-		1000 = WoL.5230 # Bad dog kills other dog
-		1000 = WoL.5231 # Bad dog kills or wounds courtier
 		
 		5000 = 0 # Chance of no yearly event
 	}
@@ -832,7 +836,7 @@ on_bi_yearly_pulse = {
 		10 = 3495	
 		10 = 3280
 		10 = 3282
-#		10 = 3283 # Event doesn't exist (commented-out for some reason)
+#		10 = 3283 # Event commented-out for whatever reason
 		10 = 3286
 		10 = 3710
 		10 = 3715
@@ -1007,10 +1011,12 @@ on_bi_yearly_pulse = {
 		#Christmas
 		10 = VIETmisc.2288
 		10 = VIETmisc.2289
-		#Moss
-		10 = VIETmisc.2290
-		10 = VIETmisc.2291
-		10 = VIETmisc.2292
+		#Animals
+		10 = VIETmisc.2297
+		10 = VIETmisc.2298
+		10 = VIETmisc.2304
+		10 = VIETmisc.2305
+		10 = VIETmisc.2307
 		
 		#CVLTVRE-SPECIFIC
 		#Turkish
@@ -1373,10 +1379,10 @@ on_yearly_childhood_pulse = {
 		#VIET CVLTVRE
 		#Turkish
 		20 = VIETnam.213
-		
-		1500 = 0
 		#Zoroastrian Sedreh Pushi, should happen for every child:
 		#1000 = VIETnam.9
+		
+		1500 = 0
 	}
 }
 
@@ -1863,7 +1869,7 @@ on_loot_settlement = {
 		5 = VIETmisc.2232
 		5 = VIETmisc.2233
 		5 = VIETmisc.2238
-		5 = VIETmisc.2239		
+		5 = VIETmisc.2239
 		
 		300 = 0
 	}

--- a/EMF/events/wol_intrigue_events.txt
+++ b/EMF/events/wol_intrigue_events.txt
@@ -2162,8 +2162,8 @@ character_event = {
 					trait = deceitful
 					trait = ambitious
 					trait = arbitrary
-					not = { opinion = { who = FROMFROMFROM value = 0 } }
-					is_rival = FROMFROMFROM
+					trait = lunatic
+					trait = possessed
 				}
 				or = {
 					any_pretender_title = {


### PR DESCRIPTION
Removed the opinion and rival bypasses from the personality check, but added lunatic and possessed (in keeping with the murder plot conditions)