### PR TITLE
Worked some tooltip magic on execute all decision

### DIFF
--- a/EMF/decisions/emf_prisoner_decisions.txt
+++ b/EMF/decisions/emf_prisoner_decisions.txt
@@ -602,7 +602,6 @@ decisions = {
 					}
 					not = { religion_group = muslim }
 				}
-				custom_tooltip = { text = emf_prisoner_execute_tt_kinslay }
 				hidden_tooltip = {
 					ROOT = { add_trait = kinslayer }
 				}
@@ -633,7 +632,13 @@ decisions = {
 					}
 				}
 				if = {
-					limit = { religion = ROOT }
+					limit = {
+						religion = ROOT
+						or = {
+							not = { dynasty = ROOT }
+							ROOT = { religion_group = muslim }
+						}
+					}
 					custom_tooltip = { text = emf_prisoner_execute_tt_same }
 					hidden_tooltip = {
 						ROOT = { piety = -10 }
@@ -642,8 +647,35 @@ decisions = {
 				if = {
 					limit = {
 						not = { religion = ROOT }
+						or = {
+							not = { dynasty = ROOT }
+							ROOT = { religion_group = muslim }
+						}
 					}
 					custom_tooltip = { text = emf_prisoner_execute_tt_infidel }
+				}
+				if = {
+					limit = {
+						religion = ROOT
+						dynasty = ROOT
+						ROOT = {
+							not = { religion_group = muslim }
+						}
+					}
+					custom_tooltip = { text = emf_prisoner_execute_tt_same_kin }
+					hidden_tooltip = {
+						ROOT = { piety = -10 }
+					}
+				}
+				if = {
+					limit = {
+						not = { religion = ROOT }
+						dynasty = ROOT
+						ROOT = {
+							not = { religion_group = muslim }
+						}
+					}
+					custom_tooltip = { text = emf_prisoner_execute_tt_infidel_kin }
 				}
 			}
 		}

--- a/EMF/decisions/emf_prisoner_decisions.txt
+++ b/EMF/decisions/emf_prisoner_decisions.txt
@@ -592,6 +592,7 @@ decisions = {
 			}
 		}
 		effect = {
+			custom_tooltip = { text = emf_prisoner_execute_tt }
 			if = {
 				limit = {
 					any_courtier = {
@@ -601,11 +602,9 @@ decisions = {
 					}
 					not = { religion_group = muslim }
 				}
-				custom_tooltip = {
-					text = become_kinslayer_tooltip
-					hidden_tooltip = {
-						ROOT = { add_trait = kinslayer }
-					}
+				custom_tooltip = { text = emf_prisoner_execute_tt_kinslay }
+				hidden_tooltip = {
+					ROOT = { add_trait = kinslayer }
 				}
 			}
 			any_courtier = {
@@ -628,11 +627,23 @@ decisions = {
 							}
 						}
 					}
-					ROOT = { piety = -10 }
+					death = {
+						death_reason = death_execution
+						killer = ROOT
+					}
 				}
-				death = {
-					death_reason = death_execution
-					killer = ROOT
+				if = {
+					limit = { religion = ROOT }
+					custom_tooltip = { text = emf_prisoner_execute_tt_same }
+					hidden_tooltip = {
+						ROOT = { piety = -10 }
+					}
+				}
+				if = {
+					limit = {
+						not = { religion = ROOT }
+					}
+					custom_tooltip = { text = emf_prisoner_execute_tt_infidel }
 				}
 			}
 		}

--- a/EMF/localisation/emf_prisoner.csv
+++ b/EMF/localisation/emf_prisoner.csv
@@ -84,9 +84,10 @@ emf_prisoner_transfer_tt;An order will be sent to §Y[Root.Host.GetTitledFirstNam
 emf_prisoner_ransom_all_tt;§Y[Root.GetTitledName]§! has prisoners who can be ransomed.\n;;;;;;;;;;;;;x
 emf_prisoner_ransom_all_tt_timer;§Y[Root.GetTitledName]§! has not recently sent ransom requests.;;;;;;;;;;;;;x
 emf_prisoner_execute_tt;This will upset the people of each prisoner's home realm, lowering their opinion of you by §R-10§!.\n;;;;;;;;;;;;;x
-emf_prisoner_execute_tt_kinslay;You have kin amongst the prisoners and will gain the trait '§YKinslayer§!'\n;;;;;;;;;;;;;x
 emf_prisoner_execute_tt_same;§Y[This.GetTitledName]§! dies! You lose §R10.00§! [Root.Religion.GetPietyName].\n;;;;;;;;;;;;;x
 emf_prisoner_execute_tt_infidel;§Y[This.GetTitledName]§! dies!\n;;;;;;;;;;;;;x
+emf_prisoner_execute_tt_same_kin;§Y[This.GetTitledName]§! dies! You lose §R10.00§! [Root.Religion.GetPietyName] and gain '§YKinslayer§!'\n;;;;;;;;;;;;;x
+emf_prisoner_execute_tt_infidel_kin;§Y[This.GetTitledName]§! dies! You gain '§YKinslayer§!'\n;;;;;;;;;;;;;x
 # Events
 emf_prisoner.0_tt;§Y[This.GetTitledFirstName]§! is asked to pay ransom.;;;;Al personaje se le ha pedido pagar el rescate.;;;;;;;;;x
 emf_prisoner.30.a_tt;§Y[This.GetTitledFirstName]§! is released from your dungeon and imprisoned by §Y[FromFrom.GetTitledFirstName]§!.;;;;;;;;;;;;;x

--- a/EMF/localisation/emf_prisoner.csv
+++ b/EMF/localisation/emf_prisoner.csv
@@ -26,7 +26,7 @@ emf_prisoner_execute_desc;Execute everyone in your dungeons.;;;;Ejecuta a todos 
 emf_prisoner.0.desc;[Root.Host.GetTitledFirstName] offers to release me from prison if I pay a ransom.;;;;[Root.Host.GetTitledFirstName] ofreció liberarte si le pagas un rescate.;;;;;;;;;x
 emf_prisoner.0.a;I will pay for my freedom.;;;;Pagaré por mi libertad.;;;;;;;;;x
 emf_prisoner.0.b;I will not pay.;;;;No pienso hacerlo.;;;;;;;;;x
-# Ask Liege for ransom - FROM is prisoner, FROMFROM is FROM's host
+# Ask Liege for ransom
 emf_prisoner.1.desc;I have received a ransom request for one of my courtiers. It is a good deal...;;;;Has recibido una solicitud de rescate por uno de tus cortesanos. Parece un buen trato...;;;;;;;;;x
 emf_prisoner.1.a;I will pay to get them back.;;;;Pagaré para traerle de vuelta;;;;;;;;;x
 emf_prisoner.1.b;I will not pay to get them back.;;;;No pienso hacerlo.;;;;;;;;;x
@@ -83,6 +83,10 @@ emf_prisoner_transfer_tt;An order will be sent to §Y[Root.Host.GetTitledFirstNam
 # Bulk actions
 emf_prisoner_ransom_all_tt;§Y[Root.GetTitledName]§! has prisoners who can be ransomed.\n;;;;;;;;;;;;;x
 emf_prisoner_ransom_all_tt_timer;§Y[Root.GetTitledName]§! has not recently sent ransom requests.;;;;;;;;;;;;;x
+emf_prisoner_execute_tt;This will upset the people of each prisoner's home realm, lowering their opinion of you by §R-10§!.\n;;;;;;;;;;;;;x
+emf_prisoner_execute_tt_kinslay;You have kin amongst the prisoners and will gain the trait '§YKinslayer§!'\n;;;;;;;;;;;;;x
+emf_prisoner_execute_tt_same;§Y[This.GetTitledName]§! dies! You lose §R10.00§! [Root.Religion.GetPietyName].\n;;;;;;;;;;;;;x
+emf_prisoner_execute_tt_infidel;§Y[This.GetTitledName]§! dies!\n;;;;;;;;;;;;;x
 # Events
 emf_prisoner.0_tt;§Y[This.GetTitledFirstName]§! is asked to pay ransom.;;;;Al personaje se le ha pedido pagar el rescate.;;;;;;;;;x
 emf_prisoner.30.a_tt;§Y[This.GetTitledFirstName]§! is released from your dungeon and imprisoned by §Y[FromFrom.GetTitledFirstName]§!.;;;;;;;;;;;;;x


### PR DESCRIPTION
I improved the logic a tiny bit so it no longer charges you piety for executing folks of a different religion, which is consistent with the execute button's behavior. Also: the individual prisoner tooltips now indicate whether you will lose piety or gain Kinslayer, making it easier to tell which prisoner you might not want to execute.