### PR TITLE
Changed renounce_iconoclasm decision

### DIFF
--- a/EMF/decisions/conversion_decisions.txt
+++ b/EMF/decisions/conversion_decisions.txt
@@ -4661,18 +4661,24 @@ decisions = {
 					character_event = { id = CM.4200 }
 				}
 			}
-			activate_title = { title = k_orthodox status = yes }
-			d_iconoclast = {
-				holder_scope = {
-					k_orthodox = {
-						grant_title = PREV
-					}
-					unsafe_religion = orthodox  # Use this effect with care
-					set_defacto_liege = ROOT
-				}
-				hidden_tooltip = { unsafe_destroy_landed_title = THIS }
+			if = {
+				limit = { NOT = { is_title_active = k_orthodox } }
+				activate_title = { title = k_orthodox status = yes }
 			}
-			activate_title = { title = d_iconoclast status = no }
+			if = {
+				limit = { is_title_active = d_iconoclast }
+				d_iconoclast = {
+					holder_scope = {
+						k_orthodox = {
+							grant_title = PREV
+						}
+						unsafe_religion = orthodox  # Use this effect with care
+						set_defacto_liege = ROOT
+					}
+					hidden_tooltip = { unsafe_destroy_landed_title = THIS }
+				}
+				activate_title = { title = d_iconoclast status = no }
+			}
 		}
 		revoke_allowed = {
 			always = no


### PR DESCRIPTION
Changed a couple of effects on the decision.
Changes about it:
*will only activate Orthodox Church if it's not already active.
*will only deactivate Iconoclast Church if it's already active.
Reason for change: it just appears on the tooltip, which is confusing in a case where the Orthodox Church is active or the Iconoclast isn't.