### PR TITLE
No [normal] laws for temporary titles

### DIFF
--- a/EMF/decisions/crown_laws.txt
+++ b/EMF/decisions/crown_laws.txt
@@ -12,6 +12,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			holder_scope = { is_republic = no }
@@ -73,6 +74,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			or = {
@@ -215,6 +217,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			or = {
@@ -400,6 +403,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			or = {
@@ -597,6 +601,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			has_law = crown_authority_3
@@ -884,6 +889,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			has_law = king_peace_1
@@ -916,6 +922,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			custom_tooltip = {
@@ -1017,6 +1024,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			has_law = crown_authority_4
@@ -1113,6 +1121,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			has_law = revokation_1
@@ -1147,6 +1156,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			custom_tooltip = {
@@ -1250,6 +1260,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			custom_tooltip = {
@@ -1354,6 +1365,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 		}
@@ -1383,6 +1395,7 @@ de_jure_laws = {
 		
 		potential = {
 			holder_scope = { is_tribal = no }
+			temporary = no
 		}
 		allow = {
 			custom_tooltip = {
@@ -1480,6 +1493,7 @@ de_jure_laws = {
 					religion = fraticelli
 				}
 			}
+			temporary = no
 		}
 		allow = {
 			year = 1000
@@ -1531,6 +1545,7 @@ de_jure_laws = {
 					religion = fraticelli
 				}
 			}
+			temporary = no
 		}
 		allow = {
 			custom_tooltip = {

--- a/EMF/decisions/emf_demesne_laws.txt
+++ b/EMF/decisions/emf_demesne_laws.txt
@@ -1,7 +1,7 @@
 # demesne_laws (set upon primary title, apply to whole demesne)
 # Vassal levy/tax focus/obligations sliders
 #
-# Written by zijistark via demesne_laws.pl v1.1.4 on Tue Dec 16 14:24:20 2014 (Pacific)
+# Written by zijistark via demesne_laws.pl v1.1.5 on Tue May 12 09:44:22 2015 (Pacific)
 # Code generation parameters:
 #   min_total_levy=-0.1
 #   max_total_levy=0.4
@@ -39,6 +39,7 @@ laws = {
 		default = yes
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -90,6 +91,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -130,6 +132,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -170,6 +173,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -210,6 +214,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -250,6 +255,7 @@ laws = {
 		feudal_opinion = 6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -306,6 +312,7 @@ laws = {
 		feudal_opinion = 0
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -358,6 +365,7 @@ laws = {
 		feudal_opinion = -6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -410,6 +418,7 @@ laws = {
 		feudal_opinion = -12
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -452,6 +461,7 @@ laws = {
 		feudal_opinion = -18
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -493,6 +503,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -530,6 +541,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -570,6 +582,7 @@ laws = {
 		default = yes
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -622,6 +635,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -662,6 +676,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -702,6 +717,7 @@ laws = {
 		temple_opinion = 6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -758,6 +774,7 @@ laws = {
 		temple_opinion = 0
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -810,6 +827,7 @@ laws = {
 		temple_opinion = -6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -862,6 +880,7 @@ laws = {
 		temple_opinion = -12
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -904,6 +923,7 @@ laws = {
 		temple_opinion = -18
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -945,6 +965,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -981,6 +1002,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1020,6 +1042,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1059,6 +1082,7 @@ laws = {
 		default = yes
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1110,6 +1134,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1149,6 +1174,7 @@ laws = {
 		city_opinion = 6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1204,6 +1230,7 @@ laws = {
 		city_opinion = 0
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1255,6 +1282,7 @@ laws = {
 		city_opinion = -6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1306,6 +1334,7 @@ laws = {
 		city_opinion = -12
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1347,6 +1376,7 @@ laws = {
 		city_opinion = -18
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1387,6 +1417,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1424,6 +1455,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1464,6 +1496,7 @@ laws = {
 		default = yes
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1516,6 +1549,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1556,6 +1590,7 @@ laws = {
 
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1596,6 +1631,7 @@ laws = {
 		feudal_opinion = 6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1638,6 +1674,7 @@ laws = {
 		feudal_opinion = 0
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1702,6 +1739,7 @@ laws = {
 		feudal_opinion = -6
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1754,6 +1792,7 @@ laws = {
 		feudal_opinion = -12
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }
@@ -1796,6 +1835,7 @@ laws = {
 		feudal_opinion = -18
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }

--- a/EMF/src/demesne_laws.pl
+++ b/EMF/src/demesne_laws.pl
@@ -6,7 +6,7 @@
 # without modification, of this program or its output is
 # expressly forbidden without the consent of the author.
 
-my $VERSION = "1.1.4";
+my $VERSION = "1.1.5";
 
 my $opt = {
 	min_total_levy      => -0.1,
@@ -262,6 +262,7 @@ EOS
 $default$opinion_effect
 
 		potential = {
+			temporary = no
 			or = {
 				not = { tier = baron }
 				holder_scope = { is_patrician = yes }


### PR DESCRIPTION
- Temporary titles (e.g., revolt titles) now no longer will have crown laws if of king- or empire-tier
- Temporary titles will now no longer have any of the non-vanilla demesne laws ([focus, obligations] x [feudal, burgher, clergy, iqta]) (they're not affected by liege levy laws during civil wars, if revolters, anyway)
- They'll still have the vanilla demesne laws which affect vassal limit, whether viceroyalties are enabled and what kind, etc. I figured that it might be dangerous to mess with these, but if so, their `allow` should also be locked to whatever initial value the title was given, ideally. Will worry about them some other time.