### PR TITLE
Allow Jomsvikings to form like other holy orders

### DIFF
--- a/EMF/EMF_changelog.txt
+++ b/EMF/EMF_changelog.txt
@@ -1,4 +1,5 @@
 EMF 3.12 [BETA]
+	The Jomsvikings can now form after religion reformation just like other pagan holy orders. Vanilla events can still create them earlier. Rejoice, ye armchair Viking warriors.
 	Court Banishment fixes:
 		The court banishment action will no longer show up in the player's own diplomatic menu.
 		Banished courtiers of a different religion will now always leave the player's realm.

--- a/EMF/events/emf_holy_orders.txt
+++ b/EMF/events/emf_holy_orders.txt
@@ -953,6 +953,147 @@ province_event = {
 	}
 }
 
+## The Jomsvikings
+## 20-29 reserved
+# The birth of the Jomsvikings (if they vanilla events didn't create them already)
+narrative_event = {
+	id = emf_holy.20
+	title = EVTNAME_TOG_4003
+	desc = emf_holy.20.desc
+	major = yes
+	
+	picture = GFX_evt_vikings_arriving_oldgods
+	
+	only_playable = yes
+	hide_from = yes
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		has_global_flag = norse_reformation
+		religion = catholic
+		NOT = {
+			is_title_active = d_jomsvikings
+		}
+		controls_religion = yes # Let it happen for the Pope - he's always around
+	}
+	
+	mean_time_to_happen = {
+		months = 36
+	}
+	
+	immediate = {
+		set_global_flag = jomsvikings_founded
+		activate_title = { title = d_jomsvikings status = yes }
+		create_character = {
+			random_traits = no
+			dynasty = random
+			religion = norse_pagan_reformed
+			culture = norse
+			female = no
+			age = 28
+			trait = tough_soldier
+			trait = brave
+			trait = strong
+			trait = zealous
+			trait = hunter
+			trait = wroth
+			trait = berserker
+		}
+		new_character = {
+			wealth = 500
+			d_jomsvikings = {
+				grant_title = PREV
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 16
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 18
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 18
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 20
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 25
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 26
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = no
+				age = 28
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = yes
+				age = 16
+			}
+			create_character = {
+				random_traits = yes
+				dynasty = random
+				religion = norse_pagan_reformed
+				culture = norse
+				female = yes
+				age = 17
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTA_TOG_4003
+		trigger = {
+			religion = norse_pagan_reformed
+		}
+	}
+	option = {
+		name = EVTOPTB_TOG_4003
+		trigger = {
+			NOT = { religion = norse_pagan_reformed }
+		}
+	}
+}
+
+
 ## General Muslim events
 ## 100-109 reserved
 # Ping event when donating money to Muslim holy order

--- a/EMF/localisation/emf_holy_orders.csv
+++ b/EMF/localisation/emf_holy_orders.csv
@@ -25,6 +25,8 @@ emf_holy.12.desc;My [GetFromRelation], [From.GetTitledFirstName], has requested 
 emf_holy.13.tt;[This.GetTitledFirstName] joins the Saqaliba.;;;;;;;;;;;;;x
 emf_holy.18.desc;Most wise [Root.GetTitledFirstName], the Saqaliba needs more castles in order to train troops and generate a supporting income. It has come to my attention that there is a suitable location in your demesne - in [FromFrom.GetName] to be specific. I am willing to pay you 100 gold in exchange for the right to construct a fortress there.\nPeace be upon you,\n\nGrand Master [From.GetFirstName];;;;;;;;;;;;;x
 emf_holy.19.desc;The Saqaliba have constructed a castle in [Root.GetName]!;;;;;;;;;;;;;x
+###
+emf_holy.20.desc;A band of fierce Vikings have established a warrior brotherhood. These Jomsvikings, as they call themselves, are devoted to Thor, Odin, and the other Norse gods. They brook no quarter on the battlefield and will permit only the strongest and ablest warriors amongst their number.\n\nThough there are those who would dismiss them as simple brigands, the Jomsvikings have vowed to defend all Norse lands being encroached by Christendom or other foreign religions.;;;;;;;;;;;;;x
 ### General Muslim Holy Order Events
 emf_holy.101.desc;Your Highness, I greet the news of your generous donation with gladness and much goodwill. You are truly a friend of our order and a stalwart defender of all that is righteous in this world. Surely your faith will be rewarded in both this life and also the next!\nMay Allah protect you,\n\nGrand Master [From.GetFirstName];;;;;;;;;;;;;x
 #### MODIFIERS;;;;;;;;;;;;;;x


### PR DESCRIPTION
Vanilla events can still form them earlier, but now they're guaranteed to show up eventually if reformation happens. (Someday the vanilla events should be fixed so they work properly on the SWMH map and so forth, but that's for another time...)