### PR TITLE
Imperial Reconquest uses region system; tiers tweaked

### DIFF
--- a/EMF+SWMH/common/cb_types/00_imperial_reconquest.txt
+++ b/EMF+SWMH/common/cb_types/00_imperial_reconquest.txt
@@ -1,4 +1,4 @@
-## normal scopes(including posttitle scopes) ##
+## normal scopes (including posttitle scopes) ##
 # ROOT = receiver
 # FROM = giver
 # <no scope change> = attacker or receiver
@@ -8,209 +8,100 @@
 # <no scope change> = thirdparty landed title	
 #
 # the following effects/triggers exists (example execution order: on_success->on_success_title->on_success_posttitle):
-# is_valid, is_valid_title, on_add, on_add_title, on_add_posttitle, on_success, on_success_title, on_success_posttitle, on_fail, on_fail_title, on_fail_posttitle, on_reverse_demand, on_reverse_demand_title, on_reverse_demand_posttitle
+# is_valid, is_valid_title, on_add, on_add_title, on_add_posttitle, on_success, on_success_title, on_success_posttitle,
+# on_fail, on_fail_title, on_fail_posttitle, on_reverse_demand, on_reverse_demand_title, on_reverse_demand_posttitle
 #
-# Added on_attacker_leader_death, on_defender_leader_death and on_thirdparty_death, which all trigger when corresponding character dies
+# Added on_attacker_leader_death, on_defender_leader_death and on_thirdparty_death, which all trigger when corresponding
+# character dies
 # These three all have war scopes, which currently has the following scope changes: 
-# attacker, defender, thirdparty(only valid if thirdparty character is involved), thirdparty_title(only valid if thirdparty title is involved)
+# attacker, defender, thirdparty (only valid if thirdparty character is involved), thirdparty_title (only valid if
+# thirdparty title is involved)
 #
 # ai_will_do: modifies value AI places on the CB compared to other CBs (default: 1)
-# can_use_gui: If otherwise valid, the CB is listed in the Diplo View, but you can't declare war unless 'can_use_gui' is also valid (also shows a trigger tooltip.)
+# can_use_gui: If otherwise valid, the CB is listed in the Diplo View, but you can't declare war unless 'can_use_gui' is
+# also valid (also shows a trigger tooltip.)
 
 
-#This casus belli replaces the vanilla one, and instead uses a tier system to determine what kingdoms are valid targets
-#To unlock a tier, all tiers before it have to be completely conquered
-#Tier 1: Byzantium
-#Tier 2: Balkans and Sicily
-#Tier 3: Italy, Levant, and Eastern/Central North Africa
-#Tier 4: Western North Africa and Iberia
-#Tier 5: France
-#Tier 6: England, Wales, and (southern) Germany
+# This casus belli replaces the vanilla one, and instead uses a tier system to determine what kingdoms are valid targets
+# To unlock a tier, all tiers before it have to be completely conquered
+# Tier 1: Byzantium
+# Tier 2: Balkans and Sicily
+# Tier 3: Italy, Levant, and Eastern/Central North Africa
+# Tier 4: Western North Africa and Iberia
+# Tier 5: France
+# Tier 6: England, Wales, and (southern) Germany
 imperial_reconquest = {
 	name = CB_NAME_IMPERIAL
 	war_name = WAR_NAME_IMPERIAL
 	sprite = 17
 	truce_days = 3650
 	is_permanent = yes
-	check_de_jure_tier = DUKE # this scans all dejure duchies for the counties which are held by or vassals(or below) of selected character. Only valid if is_permanent = yes
+	# this scans all de-jure duchies for the counties which are held by or vassals (or below) of selected character.
+	# Only valid if is_permanent = yes
+	check_de_jure_tier = DUKE
 
 	can_use_gui = {
 		ROOT = {
-			NOT = { has_character_modifier = emf_peace_pledge }
+			not = { has_character_modifier = emf_peace_pledge }
 			prestige = 500
 		}
 	}
 	
 	can_use = {
 		ROOT = {
-			OR = {
+			or = {
 				has_landed_title = e_byzantium
 				has_landed_title = e_roman_empire
 			}
 			independent = yes
 			religion_group = christian
-			NOT = { same_realm = FROM }
+			not = { same_realm = FROM }
 			mercenary = no
 			emf_cb_has_tribute_block = no
 		}
 	}
 
 	can_use_title = {
-		OR = {
-			de_jure_liege_or_above = e_byzantium
-			de_jure_liege_or_above = k_byzantium
-			de_jure_liege_or_above = k_anatolia
-			de_jure_liege_or_above = k_nikaea
-			de_jure_liege_or_above = k_epirus
-			de_jure_liege_or_above = k_trebizond
-			de_jure_liege_or_above = k_cilician
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_serbia
-					de_jure_liege_or_above = k_bulgaria
-					de_jure_liege_or_above = k_armenia
-					de_jure_liege_or_above = k_cyprus
-					title = d_antioch
-				}
-				ROOT = { # Tier 1
-					completely_controls = k_byzantium
-					completely_controls = k_anatolia
-					completely_controls = k_nikaea
-					completely_controls = k_epirus
-					completely_controls = k_trebizond
-					completely_controls = k_cilician
-
-				}
+		or = {
+			any_direct_de_jure_vassal_title = {
+				location = { region = emf_region_ir_tier_1 }
 			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_antioch
-					de_jure_liege_or_above = k_sardinia
-					de_jure_liege_or_above = k_croatia
-					de_jure_liege_or_above = k_sicily
-					de_jure_liege_or_above = k_bosnia
-				}
-				ROOT = { # Tier 2
-					completely_controls = e_byzantium
-					completely_controls = k_serbia
-					completely_controls = d_antioch
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_italy
-					de_jure_liege_or_above = k_venice
-					de_jure_liege_or_above = k_genoa
-					de_jure_liege_or_above = k_pisa
-					de_jure_liege_or_above = k_papal_state
-					de_jure_liege_or_above = k_patrimoniumpetri
-					de_jure_liege_or_above = k_syria
-					de_jure_liege_or_above = k_jerusalem
-					de_jure_liege_or_above = k_egypt
-				}
-				ROOT = { # Tier 3
-					completely_controls = e_byzantium
-					completely_controls = k_serbia
-					completely_controls = k_sicily
-					completely_controls = k_antioch
-					completely_controls = k_bosnia
-					completely_controls = k_croatia
-					completely_controls = k_sardinia
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_africa
-					de_jure_liege_or_above = k_mauretania
-					de_jure_liege_or_above = k_leon
-					de_jure_liege_or_above = k_castille
-					de_jure_liege_or_above = k_portugal
-					de_jure_liege_or_above = k_navarra
-					de_jure_liege_or_above = k_aragon
-					de_jure_liege_or_above = k_andalusia
-					de_jure_liege_or_above = k_asturias
-				}
-				ROOT = { # Tier 4
-					completely_controls = e_byzantium
-					completely_controls = k_italy
-					completely_controls = k_sicily
-					completely_controls = k_venice
-					completely_controls = k_antioch
-					completely_controls = k_bosnia
-					completely_controls = k_croatia
-					completely_controls = k_serbia
-					completely_controls = k_egypt
-					completely_controls = k_syria
-					completely_controls = k_jerusalem
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_france
-					de_jure_liege_or_above = k_aquitaine
-					de_jure_liege_or_above = k_burgundy
-					de_jure_liege_or_above = k_brittany
-				}
-				ROOT = { # Tier 5
-					completely_controls = e_byzantium
-					completely_controls = k_leon
-					completely_controls = k_castille
-					completely_controls = k_portugal
-					completely_controls = k_navarra
-					completely_controls = k_aragon
-					completely_controls = k_andalusia
-					completely_controls = k_asturias
-					completely_controls = k_africa
-					completely_controls = k_mauretania
-					completely_controls = k_italy
-					completely_controls = k_sicily
-					completely_controls = k_venice
-					completely_controls = k_antioch
-					completely_controls = k_bosnia
-					completely_controls = k_croatia
-					completely_controls = k_serbia
-					completely_controls = k_egypt
-					completely_controls = k_syria
-					completely_controls = k_jerusalem
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_england
-					de_jure_liege_or_above = k_wales
-					de_jure_liege_or_above = k_wallachia
-					de_jure_liege_or_above = k_aljazira
-					de_jure_liege_or_above = k_bavaria
-					de_jure_liege_or_above = k_germany
-					de_jure_liege_or_above = k_carinthia
-					de_jure_liege_or_above = k_lower_lorraine
-					de_jure_liege_or_above = k_upper_lorraine
-				}
-				ROOT = { # Tier 6
-					completely_controls = e_byzantium
-					completely_controls = k_france
-					completely_controls = k_aquitaine
-					completely_controls = k_burgundy
-					completely_controls = k_brittany
-					completely_controls = k_leon
-					completely_controls = k_castille
-					completely_controls = k_portugal
-					completely_controls = k_navarra
-					completely_controls = k_aragon
-					completely_controls = k_andalusia
-					completely_controls = k_asturias
-					completely_controls = k_africa
-					completely_controls = k_mauretania
-					completely_controls = k_italy
-					completely_controls = k_sicily
-					completely_controls = k_venice
-					completely_controls = k_antioch
-					completely_controls = k_bosnia
-					completely_controls = k_croatia
-					completely_controls = k_serbia
-					completely_controls = k_egypt
-					completely_controls = k_syria
-					completely_controls = k_jerusalem
+			and = {
+				ROOT = { completely_controls_region = emf_region_ir_tier_1 }
+				or = {
+					any_direct_de_jure_vassal_title = {
+						location = { region = emf_region_ir_tier_2 }
+					}
+					and = {
+						ROOT = { completely_controls_region = emf_region_ir_tier_2 }
+						or = {
+							any_direct_de_jure_vassal_title = {
+								location = { region = emf_region_ir_tier_3 }
+							}
+							and = {
+								ROOT = { completely_controls_region = emf_region_ir_tier_3 }
+								or = {
+									any_direct_de_jure_vassal_title = {
+										location = { region = emf_region_ir_tier_4 }
+									}
+									and = {
+										ROOT = { completely_controls_region = emf_region_ir_tier_4 }
+										or = {
+											any_direct_de_jure_vassal_title = {
+												location = { region = emf_region_ir_tier_5 }
+											}
+											and = {
+												ROOT = { completely_controls_region = emf_region_ir_tier_5 }
+												any_direct_de_jure_vassal_title = {
+													location = { region = emf_region_ir_tier_6 }
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}
@@ -218,13 +109,13 @@ imperial_reconquest = {
 	
 	is_valid = {
 		ROOT = {
-			OR = {
+			or = {
 				has_landed_title = e_byzantium
 				has_landed_title = e_roman_empire
 			}
 			independent = yes
 			religion_group = christian
-			NOT = { same_realm = FROM }
+			not = { same_realm = FROM }
 		}
 	}
 	
@@ -235,10 +126,8 @@ imperial_reconquest = {
 			participation_scaled_prestige = 100
 		}
 		any_attacker = {
-			limit = { NOT = { character = ROOT } }
-			hidden_tooltip = { 
-				participation_scaled_prestige = 100
-			}
+			limit = { not = { character = ROOT } }
+			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
 		
 		FROM = { prestige = -100 }
@@ -294,14 +183,12 @@ imperial_reconquest = {
 				k_papal_state = {
 					holder_scope = {
 						if = {
-							limit = {
-								NOT = { is_liege_or_above = ROOT }
-							}
+							limit = { not = { is_liege_or_above = ROOT } }
 							ROOT = {
 								vassalize_or_take_under_title = {
-									title = PREVPREVPREV #Target duchy
-									enemy = PREV #Pope
-									is_crusade = yes #Even if the title holder is not participating in the war...
+									title = PREVPREVPREV # Target duchy
+									enemy = PREV # Pope
+									is_crusade = yes # Even if the title holder is not participating in the war...
 									type = invasion
 								}
 							}
@@ -314,7 +201,10 @@ imperial_reconquest = {
 			limit = {
 				holder_scope = { character = FROM }
 			}
-			usurp_title_only = { target = ROOT type = invasion }
+			usurp_title_only = {
+				target = ROOT
+				type = invasion
+			}
 		}
 	}
 
@@ -336,21 +226,17 @@ imperial_reconquest = {
 			participation_scaled_piety = 100
 			participation_scaled_prestige = 200
 			if = {
-				limit = {
-					uses_decadence = yes
-				}
+				limit = { uses_decadence = yes }
 				participation_scaled_decadence = -10
 			}
 		}
 		any_defender = {
-			limit = { NOT = { character = FROM } }
+			limit = { not = { character = FROM } }
 			hidden_tooltip = { 
 				participation_scaled_piety = 100
 				participation_scaled_prestige = 200
 				if = {
-					limit = {
-						uses_decadence = yes
-					}
+					limit = { uses_decadence = yes }
 					participation_scaled_decadence = -10
 				}
 			}

--- a/EMF+SWMH/map/geographical_region.txt
+++ b/EMF+SWMH/map/geographical_region.txt
@@ -1,0 +1,473 @@
+# Geographical regions
+# Regions can be declared with one or more of the following fields:
+#	duchies = { }, takes duchy title names declared in landed_titles.txt
+#	counties = { }, takes county title names declared in landed_titles.txt
+#	provinces = { }, takes province id numbers declared in /history/provinces
+#	regions = { }, a region can also include other regions, however the subregions needs to be declared before the parent region. 
+#		E.g. If the region world_europe contains the region world_europe_west then world_europe_west needs to be declared as a region before (i.e. higher up in this file) world_europe.
+
+###########################################################################
+# World Regions
+#	These groups are mutually exclusive on the same tier
+###########################################################################
+
+world_europe_west_brittania = {
+	duchies = {
+		d_somerset d_canterbury d_cornwall d_hereford d_bedford d_essex d_norfolk d_fivebouroughs d_york d_lancaster d_northumberland d_channel_islands d_gwynedd d_deheubarth d_powys d_morgannwg d_oneill d_ulster d_airgialla d_breifne d_connacht d_meath d_thomond d_ossory d_leinster d_munster d_galloway d_lothian d_albany d_moray d_aberdeen d_highlands d_strathclyde d_hebrides d_orkney d_western_isles
+	}
+}
+world_europe_west_germania = {
+	duchies = {
+		d_upper_burgundy d_savoie d_aosta d_basel d_holland d_utrecht d_gelre d_frisia d_trier d_luxembourg d_pfalz d_upper_lorraine d_barleduc d_liege d_limburg d_koln d_berg d_angria d_oldenburg d_osnabruck d_bishopmunster d_bremen d_alsace d_magdeburg d_saxewittenberg d_altmark d_niederbayern d_oberbayern d_osterreich d_tyrol d_salzburg d_brunswick d_thuringia d_bamberg d_nuremberg d_koln d_rheinfranken d_wurzburg d_mainz d_baden d_thuringia d_hessen d_styria d_mecklemburg d_lubeck d_holstein d_pommerania d_lubusz d_rugen d_saxony d_brandenburg d_lausitz d_meissen d_bohemia d_moravia
+	}
+}
+world_europe_west_francia = {
+	duchies = {
+		d_artois d_alencon d_berry d_blois d_anjou d_archreims d_normandy d_nevers d_orleans d_rethel d_champagne d_valois d_burgundy d_aquitaine d_toulouse d_gevaudan d_foix d_septimania d_gascogne d_poitou d_auvergne d_limousin d_bourbon d_brittany d_provence d_dauphine d_lyon d_arles d_brabant d_hainaut d_flanders
+	}
+}
+world_europe_west_iberia = {
+	duchies = {
+		d_castilla d_segovia d_najera d_navarra d_galicia d_leon d_salamanca d_aragon d_zaragoza d_barcelona d_catalunya_nova d_teruel d_ribatejo d_beira d_porto d_beja d_algarve d_badajoz d_toledo d_sevilla d_granada d_cordoba d_la_mancha d_valencia d_murcia d_mallorca
+	}
+}
+world_europe_west = {
+	regions = {
+		world_europe_west_iberia world_europe_west_francia world_europe_west_germania world_europe_west_brittania
+	}
+}
+world_europe_north = {
+	duchies = {
+		#Sweden
+		d_uppland d_ostergotland d_vastergotland d_sodermandland d_halsingland d_gotland
+		#Norway and Iceland
+		d_iceland d_faereyar d_vestlandet d_ostlandet d_trondelag d_jamtland d_opplandene d_more
+		#Finland minus Estonia
+		d_kola d_karelia d_finland d_viipuri d_norrland d_ingria
+		#Denmark
+		d_skane d_sjaelland d_halland d_slesvig d_bornholm
+	}
+}
+world_europe_south_east = { 
+	duchies = {
+		#West ERE
+		d_thrace d_adrianopolis d_strymon d_thessalonika d_neopatras d_dyrrachion d_epirus d_cephalonia d_athens d_achaia d_krete d_cyprus d_vidin d_ohrid d_turnovo d_karvuna d_rashka d_hum d_dioclea d_slavonia d_bosnia d_usora_i_soli d_croatia d_dalmatia d_krk d_dalmatian_islands d_ragusa
+	}
+}
+world_europe_south_italy = { 
+	duchies = {
+                #Carinthia minus Styria
+		d_carinthia d_istria d_aquileia
+                ##Italy
+		#Lombardy
+                d_lombardia d_como d_verona d_parma d_susa d_monferrato d_genoa d_savona d_modena d_mantua d_lucca d_toscana d_pisa
+                #Sankt Peter's crib. 
+                d_ferrara d_ravenna d_ancona d_urbino d_spoleto d_latium
+		#Sicily
+                d_benevento d_napoli d_capua d_apulia d_loritello d_tarent d_salerno d_alvito d_calabria d_sicily
+                #Sardinia
+                d_corsica d_sardinia
+                #Venice
+                d_venice
+	}
+}
+world_europe_south = {
+	regions = {
+		world_europe_south_east world_europe_south_italy
+	}
+}
+world_europe_east = {
+	duchies = {
+		#Poland
+		d_mazovia d_greater_poland d_silesia d_lesser_poland d_kuyavia d_sieradzko-leczyckie
+                #Pommern east of the Oder
+                d_pomeralia
+                #Lithuania
+                d_prussia d_trakai d_lithuanians d_samogitia 
+                #Livonia
+                d_livonia d_courland d_talava d_zemigalia d_lettigale d_dorpat d_osel_wiek	
+		##Russia
+                # Polotsk
+                d_polotsk d_minsk
+                #Galich-Volyn 
+                d_galich d_volhynia d_zvenyhorod d_podlaise d_belz
+                #Novgorod
+                d_novgorod d_russa d_pskov d_beloozero
+                #Vladimir
+                d_vladimir d_nizhny_novgorod d_ustyg d_tver d_rostov d_moskva d_ryazan d_murom
+                #Kiev
+                d_kiev d_pereyaslavl d_novgorod-seversk d_smolensk d_toropec d_turov d_chernigov d_novosil
+                #Vepsia
+                d_bjarmia d_onega d_pechora
+		#Hungary
+		d_pecs d_gyor d_esztergom d_nyitra d_ungvar d_ujavar d_csanad d_bacs d_syrmia d_transylvania d_pest 
+		#Wallachia
+		d_wallachia d_oltenia d_moldau d_basarabia
+	}
+}
+world_asia_minor = {
+	duchies = {
+		d_opsikon d_optimatoi d_samos d_cibyrrhaeot d_anatolia d_charsianon d_sebasteia d_armeniacon d_boukellarion d_paphlagonia d_trebizond d_armenia_minor d_lykandos d_lori d_armenia d_suenik d_vaspurakan d_mesopotamia d_taron d_amida d_melitene d_edessa d_coloneia d_cappadocia d_kartli d_tao d_kakheti d_derbent d_albania d_shirvan d_abkhazia d_thracesia d_aegean_islands
+	}
+}
+world_middle_east_jerusalem = {
+	duchies = {
+		#West Syria
+		d_aleppo d_antioch d_tripoli d_homs d_damascus d_jordan
+		#Jerusalem
+		d_oultrejourdain d_ascalon d_jerusalem d_acre d_galilee
+	}
+}
+world_middle_east_arabia = {
+	duchies = {
+		#East Syria
+		d_jazira d_syria
+		#Arabia
+		d_arabia_petrae d_medina d_sanaa d_oman d_nefoud d_amman d_kermanshah d_tigris d_basra d_baghdad d_mosul d_diyareast
+		#Sinai
+		d_sinai
+	}
+}
+world_india_deccan = {
+}
+world_india_bengal = {
+}
+world_india_rajastan = {
+	duchies = {
+		#Sindh
+		d_sauvira d_bhakkar
+		#Punjab
+		d_multan d_lahore d_gandhara
+		#Delhi
+		d_kuru d_haritanaka d_mathura d_vodamayutja
+		#Gujarat
+		d_gurjara_mandala d_anartta d_saurashtra d_lata
+		#Rajputana
+		d_maru d_jangladesh d_stravani d_medapata d_ajmer
+		#Malwa
+		d_dadhipadra d_akara_dasarna d_anupa
+		#Kosala
+		d_kanyakubja d_saryupara d_jejakabhukti
+	}
+}
+world_persia = {
+	duchies = {
+		#Persia minus Mesopotamia
+                ##Persia
+                #Persia
+                d_jebal d_khoar d_fars d_kerman d_hormuz d_mafaza d_ahwaz
+                #Daylam
+                d_tabarestan d_gilan d_gurgan d_azerbaijan
+                #Khorasan
+                d_nishapur d_qohistan d_merv d_herat d_balkh
+                #Sistan
+                d_sistan d_makran
+                #Mavarannahr
+                d_soghd d_ustrushana d_ferghana d_shash d_khwarazm
+                #Kafarestan
+                d_zabolestan d_khottal
+	}
+}
+world_africa_north = {
+	duchies = {
+        ##Africa
+        #Africa
+        d_tunis d_qamuda d_tripolitania d_kabylia d_zab
+        #Maghreb
+        d_alger d_tlemcen d_tangiers d_fes d_marrakech
+        #Mauretania
+        d_draa d_adrar d_taghaza
+        #Canaries
+        d_canarias d_madeira
+        ##Sahara
+        #Sahara
+        d_hoggar d_tuat d_mzab d_air 
+        #Fezzan  
+        d_fezzan d_tibesti
+        # Kanem Bornu
+        d_bornu d_kanem d_wadai d_kawar
+        #Egypt
+        d_alexandria d_damietta d_cairo d_alwahat d_aswan d_cyrenaica
+	}
+}
+world_africa_west = {
+	duchies = {
+        #Hausaland
+        d_kano d_kebbi d_gobir
+        ##Mali
+        #Ghana
+        d_ghana d_mema d_tagant d_oualata
+        #Mali
+        d_mali d_bambuk d_kala d_wolof
+        #Takrur
+        d_takrur
+        #Songhay
+        d_songhay d_timbuktu d_mossi
+	}
+}
+world_africa_east = {
+	duchies = {
+        ## Abyssinia
+        # Adal 
+        d_berbera d_ifat d_tedjoura d_afar
+        # Abyssinia
+        d_axum d_damot d_gondar d_amhara
+        #Nubia
+        d_alodia d_nubia d_nobatia d_elatrun
+        #Sennar
+        d_sennar d_darfur
+        #Maikelebahr
+        d_aydhab d_badi d_kassala
+	}
+}
+world_africa = {
+	regions = {
+		world_africa_north world_africa_west world_africa_east
+	}
+}
+world_steppe_tarim = {
+	duchies = {
+		d_kashgar
+	}
+}
+world_steppe_west = {
+	duchies = {
+		#Perm, don't ask me why its here.
+		d_perm d_vyatka d_pelym d_perm_vychegda
+		##Tartaria
+		d_itil d_sarkel d_yaik d_sibir d_kipchak d_kimak d_maris d_bulgar d_cheremisa d_mordvins d_cherson d_crimea d_alania d_azov d_turkestan d_syr_darya
+                #Crimea
+                #Khazaria
+                d_itil d_saray d_azov d_tmutarakan
+                #V-B
+                d_bulgar d_samara d_bashkirs d_mordva d_podonye d_sura
+                #Alania 
+                d_alania d_zichia d_sarir               
+	}
+}
+world_steppe_east = {
+	duchies = {
+                #West Turkestan
+                d_yaik d_ustyurt d_dasht-i-qipchaq d_jand
+                #East Turkestan minus Kashgar
+                d_zhyetsu d_qocho d_ayaguz d_jungaria
+	}
+}
+world_steppe = {
+	regions = {
+		world_steppe_west world_steppe_east world_steppe_tarim
+	}
+}
+world_europe = {
+	regions = {
+		world_europe_west world_europe_south world_europe_east world_europe_north
+	}
+}
+world_middle_east = {
+	regions = {
+		world_middle_east_arabia world_middle_east_jerusalem
+	}
+}
+world_india = {
+	regions = {
+		world_india_deccan world_india_bengal world_india_rajastan
+	}
+}
+
+###########################################################################
+# Custom Regions
+###########################################################################
+
+custom_eastern_baltic = {
+	duchies = {
+		#Finland
+		d_karelia d_finland d_kola d_esthonia
+		#Lithuania
+		d_livonia d_prussia d_polotsk d_lithuanians d_courland d_yatviags d_samogitia
+	}
+}
+custom_frisia = {
+	duchies = {
+		d_holland d_gelre d_brabant d_flanders
+	}
+}
+custom_england = {
+	duchies = {
+		d_northumberland d_lancaster d_york d_norfolk d_bedford d_hereford d_gloucester d_canterbury d_somerset
+	}
+}
+custom_castillian = {
+	duchies = {
+		d_castilla d_asturias d_leon
+	}
+}
+custom_catalan = {
+	duchies = {
+		d_aragon d_barcelona d_valencia d_mallorca
+	}
+}
+custom_andalusian = {
+	duchies = {
+		d_cordoba d_murcia d_granada d_sevilla d_badajoz d_toledo
+	}
+}
+custom_portuguese = {
+	duchies = {
+		d_galicia d_porto d_beja d_algarve 
+	}
+}
+custom_swedish = {
+	duchies = {
+		d_uppland d_ostergotland d_vastergotland d_norrland d_bergslagen d_smaland
+	}
+}
+custom_danish = {
+	duchies = {
+		d_skane d_sjaelland d_slesvig d_holstein
+	}
+}
+custom_norwegian = {
+	duchies = {
+		d_iceland d_orkney d_vestlandet d_ostlandet d_trondelag d_jamtland
+	}
+}
+custom_scotland = {
+	duchies = {
+		d_the_isles d_galloway d_western_isles d_lothian d_albany d_moray
+	}
+}
+
+###########################################################################
+# EMF Regions
+###########################################################################
+
+emf_region_ir_tier_1 = {
+	duchies = {
+		# k_byzantium
+		d_aegean_islands d_thrace d_strymon d_thessalonika d_neopatras
+		# k_epirus
+		d_dyrrachion d_epirus d_cephalonia
+		# k_achaea
+		d_athens d_achaia
+		# k_candia
+		d_krete
+		# k_nikaea
+		d_paphlagonia d_boukellarion d_samos d_thracesia d_opsikon d_optimatoi d_cibyrrhaeot
+		# k_anatolia
+		d_charsianon d_cappadocia d_coloneia d_sebasteia d_lykandos d_anatolia d_melitene
+		# k_cyprus
+		d_cyprus
+		# k_trebizond
+		d_trebizond d_cherson d_armeniacon
+		# k_cilician
+		d_armenia_minor d_seleukeia
+		# k_ragusa
+		d_ragusa
+	}
+}
+emf_region_ir_tier_2 = {
+	duchies = {
+		# k_bulgaria
+		d_turnovo d_karvuna d_adrianopolis d_vidin d_ohrid
+		# k_serbia
+		d_rashka d_macva d_hum d_dioclea
+		# k_bosnia
+		d_bosnia d_usora_i_soli
+		# k_croatia except d_slavonia
+		d_dalmatia d_krk d_dalmatian_islands d_croatia
+		# d_antioch from k_antioch
+		d_antioch
+		# k_sicily
+		d_benevento d_napoli d_capua d_apulia d_loritello d_tarent d_salerno d_alvito d_calabria d_sicily
+	}
+}
+emf_region_ir_tier_3 = {
+	duchies = {
+		# k_carinthia except d_styria
+		d_carinthia d_istria d_aquileia
+		# d_amida and d_mesopotamia from k_armenia
+		d_amida d_mesopotamia
+		# k_jerusalem
+		d_jerusalem d_acre d_oultrejourdain d_ascalon d_galilee
+		# k_antioch except d_antioch
+		d_edessa d_tripoli
+		# k_syria
+		d_aleppo d_homs d_damascus d_jordan d_syria
+		# k_italy
+		d_lombardia d_como d_verona d_parma d_susa d_monferrato d_genoa d_savona d_modena d_mantua d_lucca d_toscana d_pisa
+		# k_patrimoniumpetri
+		d_ferrara d_ravenna d_ancona d_urbino d_spoleto d_latium
+		# k_sardinia
+		d_corsica d_sardinia
+		# k_venice
+		d_venice
+		# k_egypt
+		d_alexandria d_damietta d_cairo d_alwahat d_aswan d_cyrenaica d_sinai
+	}
+}
+emf_region_ir_tier_4 = {
+	duchies = {
+		# e_spain
+		d_castilla d_segovia d_najera
+		d_navarra
+		d_galicia d_leon d_salamanca
+		d_aragon d_zaragoza d_barcelona d_catalunya_nova d_teruel
+		d_ribatejo d_beira d_porto
+		d_beja d_algarve d_badajoz d_toledo d_sevilla d_granada d_cordoba d_la_mancha d_valencia d_murcia d_mallorca
+		# k_africa
+		d_tunis d_qamuda d_tripolitania d_kabylia d_zab
+		# k_maghreb
+		d_alger d_tlemcen d_tangiers d_fes d_marrakech
+	}
+}
+emf_region_ir_tier_5 = {
+	duchies = {
+		# k_upper_lorraine except d_pfalz
+		d_trier d_luxembourg d_pfalz d_upper_lorraine d_barleduc
+		# k_lower_lorraine except d_koln and d_berg
+		d_brabant d_liege d_hainaut d_limburg
+		# d_alsace from k_schwaben
+		d_alsace
+		# e_france
+		d_savoie d_aosta d_arles d_provence d_lyon d_dauphine d_basel d_upper_burgundy
+		d_brittany
+		d_flanders d_artois d_burgundy d_bourbon d_anjou d_normandy d_alencon d_orleans d_blois d_berry d_nevers
+		d_archreims d_champagne d_rethel d_valois
+		d_toulouse d_gevaudan d_foix d_septimania d_gascogne d_aquitaine d_auvergne d_poitou d_limousin
+		# d_channel_islands from k_england
+		d_channel_islands
+	}
+}
+emf_region_ir_tier_6 = {
+	duchies = {
+		# k_frisia
+		d_holland d_utrecht d_gelre d_frisia
+		# d_pfalz from k_upper_lorraine
+		d_pfalz
+		# d_koln and d_berg from k_lower_lorraine
+		d_koln d_berg
+		# d_mainz from k_franconia
+		d_mainz
+		# k_bavaria except d_niederbayern, d_bamberg, and d_nuremberg
+		d_tyrol d_oberbayern d_salzburg d_osterreich
+		# d_styria from k_carinthia
+		d_styria
+		# k_schwaben except d_alsace
+		d_augsburg d_baden d_chur d_zahringen d_teck d_burgau
+		# k_armenia except d_amida and d_mesopotamia
+		d_suenik d_vaspurakan d_armenia d_lori d_taron
+		# d_oltenia from k_wallachia
+		d_oltenia
+		# d_slavonia from k_croatia
+		d_slavonia
+		# k_hungary except d_nyitra, d_ungvar, and d_ujavar
+		d_esztergom d_gyor d_pecs d_csanad d_bacs d_syrmia d_pest d_transylvania
+		# k_aljazira
+		d_mosul d_jazira d_diyareast
+		# k_england except d_channel_islands
+		d_somerset d_canterbury d_cornwall d_hereford d_bedford d_essex d_norfolk d_fivebouroughs d_york d_lancaster
+		d_northumberland
+		# k_wales
+		d_gwynedd d_deheubarth d_powys d_morgannwg
+	}
+}

--- a/EMF/common/cb_types/00_imperial_reconquest.txt
+++ b/EMF/common/cb_types/00_imperial_reconquest.txt
@@ -1,4 +1,4 @@
-## normal scopes(including posttitle scopes) ##
+## normal scopes (including posttitle scopes) ##
 # ROOT = receiver
 # FROM = giver
 # <no scope change> = attacker or receiver
@@ -8,176 +8,100 @@
 # <no scope change> = thirdparty landed title	
 #
 # the following effects/triggers exists (example execution order: on_success->on_success_title->on_success_posttitle):
-# is_valid, is_valid_title, on_add, on_add_title, on_add_posttitle, on_success, on_success_title, on_success_posttitle, on_fail, on_fail_title, on_fail_posttitle, on_reverse_demand, on_reverse_demand_title, on_reverse_demand_posttitle
+# is_valid, is_valid_title, on_add, on_add_title, on_add_posttitle, on_success, on_success_title, on_success_posttitle,
+# on_fail, on_fail_title, on_fail_posttitle, on_reverse_demand, on_reverse_demand_title, on_reverse_demand_posttitle
 #
-# Added on_attacker_leader_death, on_defender_leader_death and on_thirdparty_death, which all trigger when corresponding character dies
+# Added on_attacker_leader_death, on_defender_leader_death and on_thirdparty_death, which all trigger when corresponding
+# character dies
 # These three all have war scopes, which currently has the following scope changes: 
-# attacker, defender, thirdparty(only valid if thirdparty character is involved), thirdparty_title(only valid if thirdparty title is involved)
+# attacker, defender, thirdparty (only valid if thirdparty character is involved), thirdparty_title (only valid if
+# thirdparty title is involved)
 #
 # ai_will_do: modifies value AI places on the CB compared to other CBs (default: 1)
-# can_use_gui: If otherwise valid, the CB is listed in the Diplo View, but you can't declare war unless 'can_use_gui' is also valid (also shows a trigger tooltip.)
+# can_use_gui: If otherwise valid, the CB is listed in the Diplo View, but you can't declare war unless 'can_use_gui' is
+# also valid (also shows a trigger tooltip.)
 
 
-#This casus belli replaces the vanilla one, and instead uses a tier system to determine what kingdoms are valid targets
-#To unlock a tier, all tiers before it have to be completely conquered
-#Tier 1: Byzantium
-#Tier 2: Balkans and Sicily
-#Tier 3: Italy, Levant, and Eastern/Central North Africa
-#Tier 4: Western North Africa and Iberia
-#Tier 5: France
-#Tier 6: England, Wales, and (southern) Germany
+# This casus belli replaces the vanilla one, and instead uses a tier system to determine what kingdoms are valid targets
+# To unlock a tier, all tiers before it have to be completely conquered
+# Tier 1: Byzantium
+# Tier 2: Balkans and Sicily
+# Tier 3: Italy, Levant, and Eastern/Central North Africa
+# Tier 4: Western North Africa and Iberia
+# Tier 5: France
+# Tier 6: England, Wales, and (southern) Germany
 imperial_reconquest = {
 	name = CB_NAME_IMPERIAL
 	war_name = WAR_NAME_IMPERIAL
 	sprite = 17
 	truce_days = 3650
 	is_permanent = yes
-	check_de_jure_tier = DUKE # this scans all dejure duchies for the counties which are held by or vassals(or below) of selected character. Only valid if is_permanent = yes
+	# this scans all de-jure duchies for the counties which are held by or vassals (or below) of selected character.
+	# Only valid if is_permanent = yes
+	check_de_jure_tier = DUKE
 
 	can_use_gui = {
 		ROOT = {
-			NOT = { has_character_modifier = emf_peace_pledge }
+			not = { has_character_modifier = emf_peace_pledge }
 			prestige = 500
 		}
 	}
 	
 	can_use = {
 		ROOT = {
-			OR = {
+			or = {
 				has_landed_title = e_byzantium
 				has_landed_title = e_roman_empire
 			}
 			independent = yes
 			religion_group = christian
-			NOT = { same_realm = FROM }
+			not = { same_realm = FROM }
 			mercenary = no
 			emf_cb_tribute_block_trigger = no
 		}
 	}
 
 	can_use_title = {
-		OR = {
-			de_jure_liege_or_above = e_byzantium
-			de_jure_liege_or_above = k_rum
-			title = d_coloneia
-			title = d_edessa
-			title = d_mesopotamia
-			AND = {
-				de_jure_liege_or_above = k_serbia
-				ROOT = { # Tier 1
-					completely_controls = e_byzantium
-				}
+		or = {
+			any_direct_de_jure_vassal_title = {
+				location = { region = emf_region_ir_tier_1 }
 			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_croatia
-					de_jure_liege_or_above = k_sicily
-				}
-				ROOT = { # Tier 2
-					completely_controls = e_byzantium
-					completely_controls = k_serbia
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_italy
-					de_jure_liege_or_above = k_venice
-					de_jure_liege_or_above = k_papal_state
-					de_jure_liege_or_above = k_syria
-					de_jure_liege_or_above = k_jerusalem
-					de_jure_liege_or_above = k_egypt
-					de_jure_liege_or_above = k_africa
-				}
-				ROOT = { # Tier 3
-					completely_controls = e_byzantium
-					completely_controls = k_serbia
-					completely_controls = k_sicily
-					completely_controls = k_croatia
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_mauretania
-					de_jure_liege_or_above = k_leon
-					de_jure_liege_or_above = k_castille
-					de_jure_liege_or_above = k_portugal
-					de_jure_liege_or_above = k_navarra
-					de_jure_liege_or_above = k_aragon
-					de_jure_liege_or_above = k_andalusia
-					de_jure_liege_or_above = k_asturias
-				}
-				ROOT = { # Tier 4
-					completely_controls = e_byzantium
-					completely_controls = k_italy
-					completely_controls = k_sicily
-					completely_controls = k_venice
-					completely_controls = k_serbia
-					completely_controls = k_croatia
-					completely_controls = k_syria
-					completely_controls = k_jerusalem
-					completely_controls = k_egypt
-					completely_controls = k_africa
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_france
-					de_jure_liege_or_above = k_aquitaine
-					de_jure_liege_or_above = k_brittany
-					de_jure_liege_or_above = k_burgundy
-				}
-				ROOT = { # Tier 5
-					completely_controls = e_byzantium
-					completely_controls = k_italy
-					completely_controls = k_sicily
-					completely_controls = k_venice
-					completely_controls = k_leon
-					completely_controls = k_castille
-					completely_controls = k_portugal
-					completely_controls = k_navarra
-					completely_controls = k_aragon
-					completely_controls = k_andalusia
-					completely_controls = k_asturias
-					completely_controls = k_serbia
-					completely_controls = k_croatia
-					completely_controls = k_syria
-					completely_controls = k_jerusalem
-					completely_controls = k_egypt
-					completely_controls = k_africa
-					completely_controls = k_mauretania
-				}
-			}
-			AND = {
-				OR = {
-					de_jure_liege_or_above = k_england
-					de_jure_liege_or_above = k_wales
-					de_jure_liege_or_above = k_lotharingia
-					de_jure_liege_or_above = k_bavaria
-					title = d_brabant
-				}
-				ROOT = { # Tier 6
-					completely_controls = e_byzantium
-					completely_controls = k_italy
-					completely_controls = k_sicily
-					completely_controls = k_venice
-					completely_controls = k_leon
-					completely_controls = k_castille
-					completely_controls = k_portugal
-					completely_controls = k_navarra
-					completely_controls = k_aragon
-					completely_controls = k_andalusia
-					completely_controls = k_asturias
-					completely_controls = k_france
-					completely_controls = k_aquitaine
-					completely_controls = k_burgundy
-					completely_controls = k_serbia
-					completely_controls = k_croatia
-					completely_controls = k_syria
-					completely_controls = k_jerusalem
-					completely_controls = k_egypt
-					completely_controls = k_africa
-					completely_controls = k_mauretania
-					completely_controls = k_brittany
+			and = {
+				ROOT = { completely_controls_region = emf_region_ir_tier_1 }
+				or = {
+					any_direct_de_jure_vassal_title = {
+						location = { region = emf_region_ir_tier_2 }
+					}
+					and = {
+						ROOT = { completely_controls_region = emf_region_ir_tier_2 }
+						or = {
+							any_direct_de_jure_vassal_title = {
+								location = { region = emf_region_ir_tier_3 }
+							}
+							and = {
+								ROOT = { completely_controls_region = emf_region_ir_tier_3 }
+								or = {
+									any_direct_de_jure_vassal_title = {
+										location = { region = emf_region_ir_tier_4 }
+									}
+									and = {
+										ROOT = { completely_controls_region = emf_region_ir_tier_4 }
+										or = {
+											any_direct_de_jure_vassal_title = {
+												location = { region = emf_region_ir_tier_5 }
+											}
+											and = {
+												ROOT = { completely_controls_region = emf_region_ir_tier_5 }
+												any_direct_de_jure_vassal_title = {
+													location = { region = emf_region_ir_tier_6 }
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 		}
@@ -185,13 +109,13 @@ imperial_reconquest = {
 	
 	is_valid = {
 		ROOT = {
-			OR = {
+			or = {
 				has_landed_title = e_byzantium
 				has_landed_title = e_roman_empire
 			}
 			independent = yes
 			religion_group = christian
-			NOT = { same_realm = FROM }
+			not = { same_realm = FROM }
 		}
 	}
 	
@@ -202,17 +126,15 @@ imperial_reconquest = {
 			participation_scaled_prestige = 100
 		}
 		any_attacker = {
-			limit = { NOT = { character = ROOT } }
-			hidden_tooltip = { 
-				participation_scaled_prestige = 100
-			}
+			limit = { not = { character = ROOT } }
+			hidden_tooltip = { participation_scaled_prestige = 100 }
 		}
 		
 		FROM = { prestige = -100 }
 	}
 
 	on_success_title = {
-		custom_tooltip = { 
+		custom_tooltip = {
 			text = other_invasion_succ_tip
 			hidden_tooltip = {
 				ROOT = {
@@ -245,14 +167,12 @@ imperial_reconquest = {
 				k_papal_state = {
 					holder_scope = {
 						if = {
-							limit = {
-								NOT = { is_liege_or_above = ROOT }
-							}
+							limit = { not = { is_liege_or_above = ROOT } }
 							ROOT = {
 								vassalize_or_take_under_title = {
-									title = PREVPREVPREV #Target duchy
-									enemy = PREV #Pope
-									is_crusade = yes #Even if the title holder is not participating in the war...
+									title = PREVPREVPREV # Target duchy
+									enemy = PREV # Pope
+									is_crusade = yes # Even if the title holder is not participating in the war...
 									type = invasion
 								}
 							}
@@ -265,7 +185,10 @@ imperial_reconquest = {
 			limit = {
 				holder_scope = { character = FROM }
 			}
-			usurp_title_only = { target = ROOT type = invasion }
+			usurp_title_only = {
+				target = ROOT
+				type = invasion
+			}
 		}
 	}
 
@@ -287,21 +210,17 @@ imperial_reconquest = {
 			participation_scaled_piety = 100
 			participation_scaled_prestige = 200
 			if = {
-				limit = {
-					uses_decadence = yes
-				}
+				limit = { uses_decadence = yes }
 				participation_scaled_decadence = -10
 			}
 		}
 		any_defender = {
-			limit = { NOT = { character = FROM } }
+			limit = { not = { character = FROM } }
 			hidden_tooltip = { 
 				participation_scaled_piety = 100
 				participation_scaled_prestige = 200
 				if = {
-					limit = {
-						uses_decadence = yes
-					}
+					limit = { uses_decadence = yes }
 					participation_scaled_decadence = -10
 				}
 			}

--- a/EMF/map/geographical_region.txt
+++ b/EMF/map/geographical_region.txt
@@ -1,0 +1,391 @@
+# Geographical regions
+# Regions can be declared with one or more of the following fields:
+#	duchies = { }, takes duchy title names declared in landed_titles.txt
+#	counties = { }, takes county title names declared in landed_titles.txt
+#	provinces = { }, takes province id numbers declared in /history/provinces
+#	regions = { }, a region can also include other regions, however the subregions needs to be declared before the parent region. 
+#		E.g. If the region world_europe contains the region world_europe_west then world_europe_west needs to be declared as a region before (i.e. higher up in this file) world_europe.
+
+###########################################################################
+# World Regions
+#	These groups are mutually exclusive on the same tier
+###########################################################################
+
+world_europe_west_brittania = {
+	duchies = {
+		d_northumberland d_lancaster d_york d_norfolk d_bedford d_hereford d_gloucester d_canterbury d_somerset d_gwynedd d_powys d_deheubarth d_cornwall d_the_isles d_galloway d_western_isles d_lothian d_albany d_moray d_ulster d_connacht d_meath d_leinster d_munster
+	}
+}
+world_europe_west_germania = {
+	duchies = {
+		d_upper_burgundy d_savoie d_holland d_gelre d_luxembourg d_upper_lorraine d_lower_lorraine d_alsace d_bavaria d_osterreich d_tyrol d_brunswick d_thuringia d_koln d_franconia d_baden d_swabia d_mecklemburg d_pommerania d_pomeralia d_saxony d_brandenburg d_meissen d_bohemia d_moravia
+	}
+}
+world_europe_west_francia = {
+	duchies = {
+		d_berry d_anjou d_normandy d_orleans d_champagne d_valois d_burgundy d_aquitaine d_toulouse d_gascogne d_poitou d_auvergne d_bourbon d_brittany d_provence d_dauphine d_brabant d_flanders
+	}
+}
+world_europe_west_iberia = {
+	duchies = {
+		d_castilla d_aragon d_barcelona d_valencia d_mallorca d_navarra d_asturias d_leon d_galicia d_porto d_beja d_algarve d_cordoba d_murcia d_granada d_sevilla d_badajoz d_toledo
+	}
+}
+world_europe_west = {
+	regions = {
+		world_europe_west_iberia world_europe_west_francia world_europe_west_germania world_europe_west_brittania
+	}
+}
+world_europe_north = {
+	duchies = {
+		#Sweden
+		d_uppland d_ostergotland d_vastergotland d_norrland d_bergslagen d_smaland
+		#Norway
+		d_iceland d_orkney d_vestlandet d_ostlandet d_trondelag d_jamtland
+		#Finland minus Estonia
+		d_kola d_karelia d_finland
+		#Denmark
+		d_skane d_sjaelland d_slesvig d_holstein
+	}
+}
+world_europe_south_east = { 
+	duchies = {
+		#West ERE
+		d_thrace d_adrianopolis d_thessalonika d_dyrrachion d_epirus d_athens d_achaia d_krete d_cyprus d_vidin d_turnovo d_karvuna d_rashka d_dioclea d_slavonia d_bosnia d_croatia d_dalmatia
+	}
+}
+world_europe_south_italy = { 
+	duchies = {
+		d_carinthia
+		#Italia
+		d_verona d_susa d_lombardia d_genoa d_modena d_ferrara d_toscana d_pisa d_ancona d_spoleto d_latium d_sardinia d_venice
+		#Sicily
+		d_benevento d_capua d_apulia d_salerno d_calabria d_sicily
+	}
+}
+world_europe_south = {
+	regions = {
+		world_europe_south_east world_europe_south_italy
+	}
+}
+world_europe_east = {
+	duchies = {
+		#Wendish minus Pomerania minus Bohemia
+		d_mazovia d_greater_poland d_silesia d_lesser_poland d_kuyavia d_livonia d_prussia d_polotsk d_lithuanians d_yatviags d_courland d_samogitia
+		#Russia
+		d_beloozero d_novgorod d_pskov d_rostov d_tver d_yaroslavl d_vladimir d_moskva d_kiev d_galich d_volhynia d_turov d_vitebsk d_smolensk d_chernigov d_novgorod-seversk d_ryazan d_pereyaslavl
+		#West Perm
+		d_hlynov d_bjarmia
+		#Hungary
+		d_pecs d_esztergom d_nyitra d_ungvar d_pest d_transylvania d_temes
+		#Estonia
+		d_esthonia
+		#Wallachia
+		d_wallachia d_moldau
+	}
+}
+world_asia_minor = {
+	duchies = {
+		d_nikaea d_samos d_cibyrrhaeot d_anatolia d_charsianon d_armeniacon d_paphlagonia d_trebizond d_armenia_minor d_armenia d_mesopotamia d_edessa d_coloneia d_kartli d_derbent d_abkhazia  d_thracesia d_aegean_islands
+	}
+}
+world_middle_east_jerusalem = {
+	duchies = {
+		#West Syria
+		d_aleppo d_antioch d_tripoli
+		#Jerusalem
+		d_oultrejourdain d_ascalon d_jerusalem d_galilee
+	}
+}
+world_middle_east_arabia = {
+	duchies = {
+		#East Syria
+		d_damascus d_syria
+		#Arabia
+		d_arabia_petrae d_medina d_sanaa d_oman d_nefoud d_amman d_kermanshah d_tigris d_basra d_baghdad d_mosul d_jazira
+		#Sinai
+		d_sinai
+	}
+}
+world_india_deccan = {
+	duchies = {
+		#Maharastra
+		d_vidharba d_konkana d_nasikya d_devagiri d_rattapadi
+		#Karnata
+		d_kalyani d_gangavadi d_nulambavadi d_raichur_doab
+		#Tamilakam
+		d_chola_nadu d_pandya_nadu d_chera_nadu d_tondai_nadu
+		#Andhra
+		d_vengi d_udayagiri
+		#Telingana
+		d_warangal d_racakonda
+		#Lanka
+		d_lanka d_sinhala
+	}
+}
+world_india_bengal = {
+	duchies = {
+		#Gondwana
+		d_dahala d_ratanpur
+		#Bengal
+		d_vanga d_varendra d_gauda d_nadia d_suhma
+		#Kamarupa
+		d_kamarupanagara d_para_lauhitya d_sutiya
+		#Orissa
+		d_daksina_kosala d_tosali d_kalinga d_dandakaranya
+		#Bihar
+		d_tirabhukti d_kasi d_jharkand d_magadha
+	}
+}
+world_india_rajastan = {
+	duchies = {
+		#Sindh
+		d_sauvira d_bhakkar
+		#Punjab
+		d_multan d_lahore d_gandhara
+		#Delhi
+		d_kuru d_haritanaka d_mathura d_vodamayutja
+		#Gujarat
+		d_gurjara_mandala d_anartta d_saurashtra d_lata
+		#Rajputana
+		d_maru d_jangladesh d_stravani d_medapata d_ajmer
+		#Malwa
+		d_dadhipadra d_akara_dasarna d_anupa
+		#Kosala
+		d_kanyakubja d_saryupara d_jejakabhukti
+	}
+}
+world_persia = {
+	duchies = {
+		#Persia minus Mesopotamia
+		d_khorasan d_mazandaran d_esfahan d_kerman d_fars d_hamadan d_tabriz d_azerbaijan d_baluchistan d_sistan d_kabul d_zabulistan d_khiva d_samarkand d_merv d_dihistan 
+	}
+}
+world_africa_north = {
+	duchies = {
+		d_marrakech d_fes d_tangiers d_tlemcen d_alger d_kabylia d_tunis d_tripolitania d_cyrenaica d_alexandria d_damietta d_cairo d_aswan
+	}
+}
+world_africa_west = {
+	duchies = {
+		d_songhay d_mali d_ghana d_timbuktu
+	}
+}
+world_africa_east = {
+	duchies = {
+		d_nobatia d_nubia d_sennar d_hayya d_axum d_semien d_gondar d_wag d_gojjam d_damot d_shewa d_afar d_harer
+	}
+}
+world_africa = {
+	regions = {
+		world_africa_north world_africa_west world_africa_east
+	}
+}
+world_steppe_tarim = {
+	duchies = {
+		d_kashgar d_khotan d_karashar 
+	}
+}
+world_steppe_west = {
+	duchies = {
+		#East Perm
+		d_perm d_yugra
+		#Tartaria
+		d_itil d_sarkel d_yaik d_sibir d_kipchak d_kimak d_maris d_bulgar d_cheremisa d_mordvins d_cherson d_crimea d_alania d_azov d_turkestan d_syr_darya
+	}
+}
+world_steppe_east = {
+	duchies = {
+		d_zhetysu d_kirghiz d_kumul d_altay d_otuken d_khangai d_ikh_bogd
+	}
+}
+world_steppe = {
+	regions = {
+		world_steppe_west world_steppe_east world_steppe_tarim
+	}
+}
+world_europe = {
+	regions = {
+		world_europe_west world_europe_south world_europe_east world_europe_north
+	}
+}
+world_middle_east = {
+	regions = {
+		world_middle_east_arabia world_middle_east_jerusalem
+	}
+}
+world_india = {
+	regions = {
+		world_india_deccan world_india_bengal world_india_rajastan
+	}
+}
+
+###########################################################################
+# Custom Regions
+###########################################################################
+
+custom_eastern_baltic = {
+	duchies = {
+		#Finland
+		d_karelia d_finland d_kola d_esthonia
+		#Lithuania
+		d_livonia d_prussia d_polotsk d_lithuanians d_courland d_yatviags d_samogitia
+	}
+}
+custom_frisia = {
+	duchies = {
+		d_holland d_gelre d_brabant d_flanders
+	}
+}
+custom_england = {
+	duchies = {
+		d_northumberland d_lancaster d_york d_norfolk d_bedford d_hereford d_gloucester d_canterbury d_somerset
+	}
+}
+custom_castillian = {
+	duchies = {
+		d_castilla d_asturias d_leon
+	}
+}
+custom_catalan = {
+	duchies = {
+		d_aragon d_barcelona d_valencia d_mallorca
+	}
+}
+custom_andalusian = {
+	duchies = {
+		d_cordoba d_murcia d_granada d_sevilla d_badajoz d_toledo
+	}
+}
+custom_portuguese = {
+	duchies = {
+		d_galicia d_porto d_beja d_algarve 
+	}
+}
+custom_swedish = {
+	duchies = {
+		d_uppland d_ostergotland d_vastergotland d_norrland d_bergslagen d_smaland
+	}
+}
+custom_danish = {
+	duchies = {
+		d_skane d_sjaelland d_slesvig d_holstein
+	}
+}
+custom_norwegian = {
+	duchies = {
+		d_iceland d_orkney d_vestlandet d_ostlandet d_trondelag d_jamtland
+	}
+}
+custom_scotland = {
+	duchies = {
+		d_the_isles d_galloway d_western_isles d_lothian d_albany d_moray
+	}
+}
+
+###########################################################################
+# EMF Regions
+###########################################################################
+
+emf_region_ir_tier_1 = {
+	duchies = {
+		# k_byzantium
+		d_nikaea d_samos d_aegean_islands d_thrace d_adrianopolis d_thessalonika d_dyrrachion d_epirus d_athens d_achaia
+		d_krete d_cyprus d_cibyrrhaeot
+		# k_anatolia
+		d_anatolia d_thracesia d_charsianon d_armeniacon d_paphlagonia d_trebizond
+		# k_cilicia
+		d_armenia_minor
+		# d_coloneia from k_armenia
+		d_coloneia
+	}
+}
+emf_region_ir_tier_2 = {
+	duchies = {
+		# k_bulgaria
+		d_vidin d_turnovo d_karvuna
+		# k_serbia
+		d_rashka d_dioclea
+		# k_croatia except d_slavonia
+		d_bosnia d_croatia d_dalmatia
+		# k_sicily
+		d_benevento d_capua d_apulia d_salerno d_calabria d_sicily
+		# d_cherson from k_taurica
+		d_cherson
+		# d_antioch from k_syria
+		d_antioch
+	}
+}
+emf_region_ir_tier_3 = {
+	duchies = {
+		# d_carinthia from k_bavaria
+		d_carinthia
+		# d_mesopotamia and d_edessa from k_armenia
+		d_mesopotamia d_edessa
+		# k_venice
+		d_venice
+		# e_italy
+		d_verona d_susa d_lombardia d_genoa d_modena d_ferrara d_toscana d_pisa d_ancona d_spoleto d_latium d_sardinia
+		# k_egypt
+		d_alexandria d_damietta d_cairo d_aswan d_sinai
+		# k_jerusalem
+		d_oultrejourdain d_ascalon d_jerusalem d_galilee
+		# k_syria except d_antioch
+		d_aleppo d_tripoli d_damascus d_syria
+		# d_cyrenaica from k_africa
+		d_cyrenaica
+	}
+}
+emf_region_ir_tier_4 = {
+	duchies = {
+		# e_spain
+		d_castilla
+		d_aragon d_barcelona d_valencia d_mallorca
+		d_navarra
+		d_asturias d_leon
+		d_galicia
+		d_porto d_beja d_algarve
+		d_cordoba d_murcia d_granada d_sevilla d_badajoz d_toledo
+		# k_mauretania
+		d_marrakech d_tangiers d_fes d_alger d_tlemcen
+		# k_africa except d_cyrenaica
+		d_tunis d_tripolitania d_kabylia
+	}
+}
+emf_region_ir_tier_5 = {
+	duchies = {
+		# d_brabant and d_flanders from k_frisia
+		d_brabant d_flanders
+		# k_lotharingia
+		d_luxembourg d_upper_lorraine d_lower_lorraine d_alsace
+		# e_france
+		d_berry d_anjou d_normandy d_orleans d_champagne d_valois d_burgundy
+		d_aquitaine d_toulouse d_gascogne d_poitou d_auvergne d_bourbon
+		d_brittany
+		d_provence d_savoie d_dauphine d_upper_burgundy
+	}
+}
+emf_region_ir_tier_6 = {
+	duchies = {
+		# k_frisia except d_brabant and d_flanders
+		d_holland d_gelre
+		# k_bavaria except d_carinthia
+		d_bavaria d_osterreich d_tyrol
+		# k_germany except d_brunswick and d_thuringia
+		d_koln d_franconia d_baden d_swabia
+		# d_armenia from k_armenia
+		d_armenia
+		# d_slavonia from k_croatia
+		d_slavonia
+		# k_hungary except d_nyitra and d_ungvar
+		d_pecs d_esztergom d_pest d_transylvania d_temes
+		# d_wallachia from k_dacia
+		d_wallachia
+		# d_mosul and d_jazira from k_mesopotamia
+		d_mosul d_jazira
+		# k_england
+		d_northumberland d_lancaster d_york d_norfolk d_bedford d_hereford d_gloucester d_canterbury d_somerset
+		# k_wales
+		d_gwynedd d_powys d_deheubarth d_cornwall
+	}
+}


### PR DESCRIPTION
swmh-integ is where we want to merge this, right?

There were a couple of differences in the EMF and EMF+SWMH versions of 00_imperial_reconquest.txt besides just the duchy lists, so I left them separate. DIff those two files together to see when I mean. Maybe they can be reduced to one like you mentioned was your intention, but I don't know how to do it.

Did I implement the CB-checking logic in the best way?

The regions have been tweaked in two ways since you last saw them (⇒ http://imgur.com/a/ndyfN).

- Vanilla regions have been added, more or less matching the SWMH regions.
- Each tier's region no longer includes the lesser tiers’ regions. The regions are mutually exclusive.
- I tweaked tiers 5 and 6 a little. The French–German border doesn’t mean much to a Roman Empire, so I moved (most of) Lorraine from the German tier to the Gallic tier. IMO dividing the last 3 tiers is pretty arbitrary anyway—but do you think that makes more sense?

(This commit does not touch the CB-checking decisions.)