### PR TITLE
Update wol_business_events.txt

### DIFF
--- a/EMF/events/wol_business_events.txt
+++ b/EMF/events/wol_business_events.txt
@@ -726,11 +726,6 @@ character_event = {
 		trigger = {
 			learning = 10
 		}
-		hidden_tooltip = {
-			FROM = {
-				character_event = { id = WoL.10117 }
-			}
-		}
 	}
 	
 	option = {


### PR DESCRIPTION
Prevent WoL.10117 firing twice.
WoL.10117 can fire twice through hidden_tooltip(from learning>10 option) and after clauses.